### PR TITLE
feature: add 'NsCDE' environment qualifier to dex-autostart call

### DIFF
--- a/NsCDE/config/NsCDE-Init.conf
+++ b/NsCDE/config/NsCDE-Init.conf
@@ -8,7 +8,7 @@
 DestroyFunc CommonInitFunction
 AddToFunc CommonInitFunction
 + I Test (x pnmixer, !f "$[HOME]/.config/autostart/pnmixer.desktop") Exec exec pnmixer
-+ I Test (x dex-autostart) Exec exec dex-autostart -s $[HOME]/.config/autostart -a
++ I Test (x dex-autostart) Exec exec dex-autostart -e NsCDE -s $[HOME]/.config/autostart -a
 + I Test (!f "$[FVWM_USERDIR]/NsCDE.conf") f_FirstSetup
 
 # Leave this outside function, contains breaks


### PR DESCRIPTION
Very trivial patch to add an environment qualifier to the `dex-autostart` call in `NsCDE-Init`.  This is useful for users who use multiple desktop environments, as not all autostarts are suitable for all environments.  (Personal use case: needing to start `nm-applet` for XFCE and NsCDE, but not GNOME.)

This should *only* affect `.desktop` files which use `OnlyShownIn` or `NotShownIn`.  `.desktop` files without either will be autostarted in any DE.