### PR TITLE
Disable xscreensaver startup splash

### DIFF
--- a/NsCDE/config/NsCDE-Functions.conf
+++ b/NsCDE/config/NsCDE-Functions.conf
@@ -784,7 +784,7 @@ AddToFunc f_Xscreensaver
 + I Test (EnvMatch infostore.xsc_cmd -prefs) Exec exec xscreensaver-command $0
 + I Test (EnvMatch infostore.xsc_cmd -restart) Exec exec pkill -u $[USER] xscreensaver
 + I Test (EnvMatch infostore.xsc_cmd -restart) Schedule 1000 Exec exec xscreensaver
-+ I Test (EnvMatch infostore.xsc_cmd -start) Schedule 1000 Exec exec xscreensaver
++ I Test (EnvMatch infostore.xsc_cmd -start) Schedule 1000 Exec exec xscreensaver -no-splash
 + I Test (EnvMatch infostore.xsc_cmd -kill) Exec exec pkill -u $[USER] -xf xscreensaver
 
 # Standalone XSETTINGS daemon xsettingsd support


### PR DESCRIPTION
To have a better view of the NsCDE startup splash logo I would recommend
disabling the xscreensaver splash.