### PR TITLE
Add firefox-bin to the fallback list

### DIFF
--- a/NsCDE/share/fallback/app-catalog/www-browser
+++ b/NsCDE/share/fallback/app-catalog/www-browser
@@ -1,4 +1,5 @@
 firefox
+firefox-bin
 brave-browser
 yandex-browser
 yandex-browser-beta


### PR DESCRIPTION
For example on Gentoo there is no `firefox` binary or firefox symlink to the original executable. They provide a script which is called `firefox-bin` (in /usr/bin) which exec the correct firefox version provided in /opt/firefox.

I'm not sure if that might be suitable for other operating systems or linux distributions as well.