### PR TITLE
Better error handling for sysinfo.py

### DIFF
--- a/NsCDE/bin/sysinfo.py
+++ b/NsCDE/bin/sysinfo.py
@@ -20,15 +20,18 @@ print (platform.node().split(".", 1)[0])
 # Uname mpi
 print (platform.processor(), platform.machine(), os.uname()[4])
 
-# Internet (IP) Address
-print (socket.gethostbyname(socket.gethostname()))
+try:
+    # Internet (IP) Address
+    print (socket.gethostbyname(socket.gethostname()))
+except:
+    print ("(none)")
 
 # Internet Domain
-finddomain = socket.getfqdn(socket.gethostbyname(socket.gethostname()))
-if '.' in finddomain:
+try:
+    finddomain = socket.getfqdn(socket.gethostbyname(socket.gethostname()))
     domainpart = finddomain.split(".", 1)[1]
     print (domainpart)
-else:
+except:
     print ("(none)")
 
 try:


### PR DESCRIPTION
If sysinfo.py fails with an exception the output couldn't be shown correctly in the "Workstation Info". For that reason python should handle the exceptions and return "none" if something fails.

### Example error

```
 ./sysinfo.py 
tm
havanna
Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz x86_64 x86_64
Traceback (most recent call last):
  File "./sysinfo.py", line 24, in <module>
    print (socket.gethostbyname(socket.gethostname()))
socket.gaierror: [Errno -2] Name or service not known
```

![2020-07-06-232231_504x395_scrot](https://user-images.githubusercontent.com/315645/86646518-9d8b8480-bfdf-11ea-88b6-90aa35a0221f.png)