### PR TITLE
Pass build flags from the environment if available

### DIFF
--- a/src/XOverrideFontCursor/Makefile
+++ b/src/XOverrideFontCursor/Makefile
@@ -1,5 +1,9 @@
+CC ?= gcc
+CFLAGS ?=
+LDFLAGS ?=
+
 XOverrideFontCursor.so:
-	gcc -I/usr/include/X11 -I/usr/local/include/X11 -I/usr/local/include -I/usr/X11R6/include -I/usr/X11R7/include -I/usr/X11R6/include/X11 -I/usr/X11R7/include/X11 -L/usr/X11R6/lib -L/usr/X11R7/lib -L/usr/local/lib -lX11 -fPIC -shared XOverrideFontCursor.c -o XOverrideFontCursor.so
+	$(CC) -I/usr/include/X11 -I/usr/local/include/X11 -I/usr/local/include -I/usr/X11R6/include -I/usr/X11R7/include -I/usr/X11R6/include/X11 -I/usr/X11R7/include/X11 -L/usr/X11R6/lib -L/usr/X11R7/lib $(CFLAGS) -L/usr/local/lib -lX11 -fPIC $(LDFLAGS) -shared XOverrideFontCursor.c -o XOverrideFontCursor.so
 
 clean:
 	rm XOverrideFontCursor.so

--- a/src/colorpicker/Makefile
+++ b/src/colorpicker/Makefile
@@ -1,7 +1,9 @@
-CC=gcc
+CC ?= gcc
+CFLAGS ?=
+LDFLAGS ?=
 
 colorpicker: main.c
-	$(CC) -o colorpicker main.c `pkg-config --libs --cflags x11`
+	$(CC) -o colorpicker $(CFLAGS) main.c `pkg-config --libs --cflags x11` $(LDFLAGS)
 
 clean:
 	rm -f colorpicker

--- a/src/pclock-0.13.1/Makefile
+++ b/src/pclock-0.13.1/Makefile
@@ -1,5 +1,5 @@
 all:
-	(cd src && make all)
+	cd src && $(MAKE) all
 
 install:
-	(cd src && make install)
+	cd src && $(MAKE) install

--- a/src/pclock-0.13.1/src/Makefile
+++ b/src/pclock-0.13.1/src/Makefile
@@ -7,8 +7,9 @@ DEFAULT_XPM = Fpclock.xpm
 
 INCDIR = -I/usr/X11R6/include -I/usr/X11R7/include -I/usr/include -I/usr/local/include -I.
 LIBDIR = -L/usr/X11R6/lib -L/usr/X11R7/lib -L/usr/lib64 -L/usr/local/lib
-CC = gcc
-CFLAGS = -O2 -g -Wall
+CC ?= gcc
+CFLAGS ?= -O2 -g -Wall
+LDFLAGS ?=
 LIBS = -lXpm -lXext -lX11 -lm
 
 ###############################################################################
@@ -34,7 +35,7 @@ Graphics.o: PClock.h Default.xpm
 Main.o: PClock.h Defaults.h Version.h
 
 $(PROG): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBDIR) $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBDIR) $(LDFLAGS) $(LIBS)
 
 ###############################################################################
 


### PR DESCRIPTION
Allow the environment to pass in build flags. This is useful when packaging NsCDE for distributions, among other things. Also fix the pclock Makefile to properly handle parallelism while at it.