### PR TITLE
Point to NsCDE AUR package in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,13 +93,10 @@ instead. (optional)
 
 - Arch / Artix / Manjaro
 ``` sh
-sudo pacman -Syyu
-sudo pacman -S trizen
-trizen -Syyu
-trizen -S ksh xorg xdotool imagemagick xscreensaver \
-    python-yaml python-pyqt5 qt5ct qt5-styleplugins \
-    stalonetray xterm python2 python-pyxdg libstroke \
-    xsettingsd fvwm3 perl-file-mimeinfo gkrellm rofi xclip
+# Use your AUR helper of choice (e. g. trizen) to install the package
+trizen -S nscde
+# Alternatively install the -git package to get the latest sources
+trizen -S nscde-git
 ```
 
 - Debian / Devuan / Ubuntu / Mint / MX Linux


### PR DESCRIPTION
I just pushed two PKGBUILDs to the Arch User Repository.
https://aur.archlinux.org/packages/nscde for the latest
release and https://aur.archlinux.org/packages/nscde-git
for the latest git revision. This is customary for AUR
packages.

With those two PKGBUILDs it should be possible to install
NsCDE like any other AUR package.