### PR TITLE
have fvwm2 take precedence over fvwm

### DIFF
--- a/bin/nscde.in
+++ b/bin/nscde.in
@@ -61,7 +61,7 @@ fi
 # Find fvwm(1) binary. This is a critical point.
 # We cannot continue without main workforce.
 if [ "x$FVWM_BIN" == "x" ]; then
-   for fvwmname in fvwm3 fvwm fvwm2
+   for fvwmname in fvwm3 fvwm2 fvwm
    do
       FVWM_BIN=$(whence -p $fvwmname)
       if (($? == 0)); then


### PR DESCRIPTION
OpenBSD ships with an incompatible Fvwm 2.2 in the base system. Fvwm 2.6 can be downloaded from ports, but it will have the binary name fvwm2 to avoid conflicts; therefore, fvwm2 must take precedence over fvwm in the nscde launch script.