### PR TITLE
Remove `libstroke`-related commands from the "Void Linux" section of INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -217,14 +217,6 @@ cd ~
 git clone --depth 1 https://github.com/att/ast.git
 ./bin/package make
 sudo ./bin/package install
-
-cd ~
-wget http://ftp.udc.es/debian/pool/main/libs/libstroke/libstroke_0.5.1.orig.tar.gz
-tar -zxvf libstroke_0.5.1.orig.tar.gz
-cd libstroke-0.5.1
-./configure
-make
-sudo make install
 ```
 
 - SparkyLinux


### PR DESCRIPTION
https://github.com/fvwmorg/fvwm3/issues/165

From https://github.com/mikeandmore/fvwm3/commit/e0dad0913c683759219fa394810b5126a9c78447:

> ### Remove support for libstroke
>
> Although mouse gestures via libstroke were a nice experiment, its use
> never really took off, in all but a few configurations.
>
> Given the library itself is no longer maintained, some Linux
> distributions have stopped shipping it altogether.  Although FVWM3 can
> be told to not compile with libstroke support, removing the code
> altogether makes sense.