### PR TITLE
Add LXQt support

### DIFF
--- a/doc/examples/lxqt-session-integration/README
+++ b/doc/examples/lxqt-session-integration/README
@@ -1,0 +1,11 @@
+You must use lxqt-config-session to tweak LXQt in the following way:
+- In LXQt Modules, uncheck everything except PolicyKit manager and power management.
+- In X11 settings, type nscde as the window manager.
+
+Optionally you can also turn off the confirmation prompt before logging out in base settings
+of LXQt session settings.
+
+If you want logging out to work properly, you need to add this into your ~/.NsCDE/NsCDE.conf:
+SetEnv QuitCmd "Exec exec lxqt-leave --logout"
+
+You should also make sure that "Configure GTK styles" is unchecked in lxqt-config-appearance

--- a/lib/scripts/StyleMgr
+++ b/lib/scripts/StyleMgr
@@ -751,6 +751,12 @@ Widget 17
             Do {Test (!x mate-session-properties) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No mate-session-properties found." "NoCmd"}
             Set $CheckDeskRc = {Listed}
          End
+         If $CheckDesk == {LXQt} Then
+         Begin
+               Do {Test (x lxqt-config-session) Exec exec lxqt-config-session}
+               Do {Test (!x lxqt-config-session) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No lxqt-config-session found." "NoCmd"}
+               Set $CheckDeskRc = {Listed}
+         End
          If $CheckDesk == {LXDE} Then
          Begin
             Do {Test (x lxsession-edit) Exec exec lxsession-edit}

--- a/lib/scripts/StyleMgr
+++ b/lib/scripts/StyleMgr
@@ -743,44 +743,41 @@ Widget 17
          ShowWidget 6
          ChangePosition 6 719 31
          ChangeSize 6 68 77
-         Set $CheckSessionManager = (GetOutput {echo $SESSION_MANAGER} 1 -1)
          Set $CheckDesk = (GetOutput {echo $XDG_CURRENT_DESKTOP} 1 -1)
          Set $CheckDeskRc = {NotListed}
-         If $CheckSessionManager <> {} Then
+         If $CheckDesk == {MATE} Then
          Begin
-            If $CheckDesk == {MATE} Then
-            Begin
-               Do {Test (x mate-session-properties) Exec exec mate-session-properties}
-               Do {Test (!x mate-session-properties) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No mate-session-properties found." "NoCmd"}
-               Set $CheckDeskRc = {Listed}
-            End
-            If $CheckDesk == {LXDE} Then
-            Begin
-               Do {Test (x lxsession-edit) Exec exec lxsession-edit}
-               Do {Test (!x lxsession-edit) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No lxsession-edit found." "NoCmd"}
-               Set $CheckDeskRc = {Listed}
-            End
-            If $CheckDesk == {GNOME} Then
-            Begin
-               Do {Test (x gnome-tweaks) Exec exec gnome-tweaks}
-               Do {Test (!x gnome-tweaks) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No gnome-tweaks found." "NoCmd"}
-               Set $CheckDeskRc = {Listed}
-            End
-            If $CheckDesk == {KDE} Then
-            Begin
-               Do {Test (x kcmshell5) Exec exec kcmshell5 kcmsmserver autostart kcmkded}
-               Do {Test (!x kcmshell5) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No kcmshell5 found." "NoCmd"}
-               Set $CheckDeskRc = {Listed}
-            End
-
-            If $CheckDeskRc == {NotListed} Then
-            Begin
-               Do {None (NsCDE-Notifier.NotSupp) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "Session Manager from desktop } $CheckDesk { not (yet) supported." "NotSupp"}
-            End
+            Do {Test (x mate-session-properties) Exec exec mate-session-properties}
+            Do {Test (!x mate-session-properties) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No mate-session-properties found." "NoCmd"}
+            Set $CheckDeskRc = {Listed}
          End
-         Else
+         If $CheckDesk == {LXDE} Then
          Begin
-            Do {None (NsCDE-Notifier.NoSess) f_Notifier "Style Manager" "Dismiss" "NsCDE/Info.xpm" "NsCDE appears not to be running under the X Session Manager." "NoSess"}
+            Do {Test (x lxsession-edit) Exec exec lxsession-edit}
+            Do {Test (!x lxsession-edit) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No lxsession-edit found." "NoCmd"}
+            Set $CheckDeskRc = {Listed}
+         End
+         If $CheckDesk == {GNOME} Then
+         Begin
+            Do {Test (x gnome-tweaks) Exec exec gnome-tweaks}
+            Do {Test (!x gnome-tweaks) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No gnome-tweaks found." "NoCmd"}
+            Set $CheckDeskRc = {Listed}
+         End
+         If $CheckDesk == {KDE} Then
+         Begin
+            Do {Test (x kcmshell5) Exec exec kcmshell5 kcmsmserver autostart kcmkded}
+            Do {Test (!x kcmshell5) None (NsCDE-Notifier.NoCmd) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "No kcmshell5 found." "NoCmd"}
+            Set $CheckDeskRc = {Listed}
+         End
+         If $CheckDesk == {NsCDE} Then
+         Begin
+            Do {None (NsCDE-Notifier.NoSess) f_Notifier "Style Manager" "Dismiss" "NsCDE/Info.xpm" "NsCDE appears not to be integrated into a session manager." "NoSess"}
+            Set $CheckDeskRc = {Listed}
+         End
+
+         If $CheckDeskRc == {NotListed} Then
+         Begin
+            Do {None (NsCDE-Notifier.NotSupp) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "Session Manager from desktop } $CheckDesk { not (yet) supported." "NotSupp"}
          End
       End
 End


### PR DESCRIPTION
This pull request adds support for LXQt, that is, showing lxqt-config-session when pressing on Startup in the style manager, and also adds documentation on how to integrate NsCDE into LXQt seamlessly.

Please note that to merge this pull request you should merge first #230, so you can review changes independently.