### PR TITLE
[1/3] fix: correct user-facing English messages

### DIFF
--- a/bin/nscde.in
+++ b/bin/nscde.in
@@ -10,7 +10,7 @@
 
 # Basic sanity check.
 if [ -z $HOME ]; then
-   echo "Error: HOME not set." >&2
+   echo "Error: HOME is not set." >&2
    exit 2
 else
    export NSCDE_VERSION="@VERSION@"
@@ -35,7 +35,7 @@ echo "${DpiInfo}" | egrep -q "^[[:digit:]]+x[[:digit:]]+$"
 if (($? == 0)); then
    export DPI="${DpiInfo##*x}"
 else
-   echo "Warning: DPI \"$DPI\" is not recognized as X DPI specification. Setting DPI to 96"
+   echo "Warning: DPI value $DPI is not a valid X DPI specification; using 96 instead."
    export DPI=96
 fi
 
@@ -70,8 +70,7 @@ if [ "x$FVWM_BIN" == "x" ]; then
    done
 fi
 if [ "x$FVWM_BIN" == "x" ]; then
-   echo "Error: cannot detect niether fvwm, fvwm2 nor fvwm3 in $PATH and"
-   echo "environment variable FVWM_BIN is not set. Exiting."
+   echo "Error: none of fvwm, fvwm2, or fvwm3 was found in $PATH, and FVWM_BIN is not set. Exiting."
    exit 3
 fi
 
@@ -82,17 +81,17 @@ if [ -r "${FVWM_USERDIR}/Xdefaults" ]; then
    if (($? == 0)); then
       xrdb -remove && xrdb -cpp /usr/bin/cpp < ${FVWM_USERDIR}/Xdefaults
    else
-      echo "Warning: cannot find xrdb or cpp in ${PATH}, ${FVWM_USERDIR}/Xdefaults will not be processed"
+      echo "Warning: xrdb or cpp was not found in ${PATH}; ${FVWM_USERDIR}/Xdefaults will not be processed."
    fi
 else
-   echo "Warning: cannot read ${FVWM_USERDIR}/Xdefaults file"
+   echo "Warning: cannot read ${FVWM_USERDIR}/Xdefaults."
 fi
 
 # Handle our app-defaults dir if it exists.
 if [ -d "${FVWM_USERDIR}/app-defaults" ]; then
    export XAPPLRESDIR="${FVWM_USERDIR}/app-defaults"
 else
-   echo "Warning: cannot find ${FVWM_USERDIR}/app-defaults directory"
+   echo "Warning: directory ${FVWM_USERDIR}/app-defaults was not found."
 fi
 
 # Set xset(1), setxkbmap(1), xgamma(1), xmodmap(1) and such things from
@@ -100,7 +99,7 @@ fi
 if [ -r "${FVWM_USERDIR}/Xset.conf" ]; then
    . "${FVWM_USERDIR}/Xset.conf"
 else
-   echo "Notice: ${FVWM_USERDIR}/Xset.conf does not exist"
+   echo "Notice: ${FVWM_USERDIR}/Xset.conf does not exist."
 fi
 
 # Early user customizations if needed can be set here.
@@ -119,4 +118,3 @@ fi
 # Do not be picky if there is some failure left.
 # Do the best effort and exit always with 0.
 exit 0
-

--- a/bin/nscde_fvwmclnt.in
+++ b/bin/nscde_fvwmclnt.in
@@ -50,6 +50,5 @@ fi
 if [ "x$FVWM_CLNT" != "x" ]; then
    exec $FVWM_CLNT "$@"
 else
-   echo "ERROR: Cannot find suitable FvwmCommand for your setup." >&2
+   echo "Error: cannot find a suitable FvwmCommand for this setup." >&2
 fi
-

--- a/lib/fvwm-modules/FvwmScript.in
+++ b/lib/fvwm-modules/FvwmScript.in
@@ -22,7 +22,7 @@ if [ -x "$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so" ]; then
             fi
          fi
       else
-         echo "Notice: $NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so is already ld-preloaded, skipping" >&2
+         echo "Notice: $NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so is already preloaded; skipping it." >&2
       fi
    else
       export LD_PRELOAD="$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so"
@@ -31,4 +31,3 @@ fi
 
 # Call the real FvwmScript
 exec ${FVWM_MODULEDIR}/FvwmScript "$@"
-

--- a/lib/python/Opts.py.in
+++ b/lib/python/Opts.py.in
@@ -37,7 +37,7 @@ class Opts():
     # load and replace current object namespace with loaded
     # note: this way because yaml.load/save looks nicer when works on dict instead of class
     def load(self,filename):
-        print ('Opts() LOADING '+filename)
+        print ('Loading options from: '+filename)
         with open(filename, 'r') as stream:
             tmpdict = yaml.load(stream)
         # if file is empty(tmpdict=None), do nothing. Then in all classes default values for opts will be used
@@ -48,10 +48,10 @@ class Opts():
     # save namespace (or something)
     def save(self,filename):
         backup=filename+'.backup'
-        print ('Copying old config file to '+backup)
+        print ('Backing up configuration to: '+backup)
         cmd='cp'+' '+filename+' '+backup
         output = subprocess.check_output(cmd, shell=True)
-        print ('Opts() SAVING CONFIG FILE '+filename)
+        print ('Saving configuration to: '+filename)
         with open(filename, 'w') as outfile:
             yaml.dump(self.__dict__, outfile)
 
@@ -90,4 +90,3 @@ def main():
 
 if __name__ == '__main__':
    main()
-

--- a/lib/python/Theme.py.in
+++ b/lib/python/Theme.py.in
@@ -26,9 +26,9 @@ class Theme():
         # checkDir(userhome)
         homedotthemes=os.path.join(userhome,'.themes')
         if not os.path.exists(homedotthemes):
-            print ('Dot themes dir not found. Creating: '+homedotthemes)
+            print ('Themes directory not found; creating: '+homedotthemes)
             try: os.makedirs(homedotthemes)
-            except OSError as e: sys.stderr.write("Failed to create ~/.themes stop.\n"), e
+            except OSError as e: sys.stderr.write("Failed to create ~/.themes: "+str(e)+"\n")
             sys.exit(2)
 
         # if .themes/NsCDE not exist: copy
@@ -39,8 +39,8 @@ class Theme():
             print (Globals.themesrcdir)
             #sys.exit()
             if not os.path.exists(Globals.themedir):
-                print ('NOT FOUND THEME DIR '+Globals.themedir)
-                print ('Trying to copy from default ')
+                print ('Theme directory not found: '+Globals.themedir)
+                print ('Copying the default theme from: '+Globals.themesrcdir)
                 shutil.copytree(Globals.themesrcdir,Globals.themedir,symlinks=True)
 
             if os.path.lexists(Globals.userthemedir): shutil.rmtree(Globals.userthemedir)
@@ -60,8 +60,8 @@ class Theme():
 
     # Zees eeze nedded unly vunce
     def doUpdateTheme(self):
-        print ("Generate for Gtk2:", self.opts.themeGtk2)
-        print ("Generate for Gtk3:", self.opts.themeGtk3)
+        print ("Generating Gtk2 theme:", self.opts.themeGtk2)
+        print ("Generating Gtk3 theme:", self.opts.themeGtk3)
 
         palettefilefullpath=os.path.join(Globals.palettedir,self.opts.currentpalettefile)
 
@@ -74,4 +74,3 @@ class Theme():
             filename=os.path.join(Globals.userthemedir,'gtk-3.20/cdecolors.css')
             ThemeGtk.gengtk3colors(filename,self.opts)
             ThemeGtk.updateThemeImages(self.opts)
-

--- a/lib/scripts/BackdropMgr.in
+++ b/lib/scripts/BackdropMgr.in
@@ -726,7 +726,7 @@ Widget 12
                   # Workaround FvwmScript lack of programatic cases or elifs ...
                   If $CheckPhotoFileConv <> {noconv} Then
                   Begin
-                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "Error from $[NSCDE_TOOLSDIR]/backdropmgr: } $CheckPhotoFileConv {."}
+                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "Error from backdropmgr: } $CheckPhotoFileConv {."}
                   End
                End
             End
@@ -1006,4 +1006,3 @@ Widget 19
          Do {f_DisplayURL "$[gt.Backdrop Style Manager]" html/NsCDE-BackdropMgr.html}
       End
 End
-

--- a/lib/scripts/FontMgr.in
+++ b/lib/scripts/FontMgr.in
@@ -1074,7 +1074,7 @@ Widget 15
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1144,7 +1144,7 @@ Widget 16
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1214,7 +1214,7 @@ Widget 17
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1284,7 +1284,7 @@ Widget 18
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1354,7 +1354,7 @@ Widget 19
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -2236,4 +2236,3 @@ Widget 101
       End
    End
 End
-

--- a/lib/scripts/GWMOptions
+++ b/lib/scripts/GWMOptions
@@ -416,7 +416,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\" } (Gettext {emerged while appending backdrops value in}) { } $WSMCONF {." "e1"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\" } (Gettext {occurred while appending backdrops value in}) { } $WSMCONF {." "e1"}
                   Quit
                End
             End
@@ -428,7 +428,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\" } (Gettext {emerged while changing backdrops value in}) { } $WSMCONF
+                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\" } (Gettext {occurred while changing backdrops value in}) { } $WSMCONF
                   Quit
                End
             End
@@ -446,7 +446,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\" } (Gettext {emerged while appending highlight value in}) { } $WSMCONF {." "e3"}
+                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\" } (Gettext {occurred while appending highlight value in}) { } $WSMCONF {." "e3"}
                   Quit
                End
             End
@@ -458,7 +458,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\" } (Gettext {emerged while changing highlight value in}) { } $WSMCONF {." "e4"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\" } (Gettext {occurred while changing highlight value in}) { } $WSMCONF {." "e4"}
                   Quit
                End
             End
@@ -476,7 +476,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\" } (Gettext {emerged while appending workspace name label value in}) { } $WSMCONF {." "e5"}
+                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\" } (Gettext {occurred while appending workspace name label value in}) { } $WSMCONF {." "e5"}
                   Quit
                End
             End
@@ -488,7 +488,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\" } (Gettext {emerged while changing workspace name label value in}) { } $WSMCONF {." "e6"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\" } (Gettext {occurred while changing workspace name label value in}) { } $WSMCONF {." "e6"}
                   Quit
                End
             End
@@ -506,7 +506,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\" } (Gettext {emerged while appending GWM rows value in}) { } $WSMCONF {." "e7"}
+                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\" } (Gettext {occurred while appending GWM rows value in}) { } $WSMCONF {." "e7"}
                   Quit
                End
             End
@@ -518,7 +518,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\" } (Gettext {emerged while changing GWM rows value in}) { } $WSMCONF {." "e8"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\" } (Gettext {occurred while changing GWM rows value in}) { } $WSMCONF {." "e8"}
                   Quit
                End
             End
@@ -536,7 +536,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\" } (Gettext {emerged while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\" } (Gettext {occurred while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
                   Quit
                End
             End
@@ -548,7 +548,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\" } (Gettext {emerged while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\" } (Gettext {occurred while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
                   Quit
                End
             End
@@ -566,7 +566,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\" } (Gettext {emerged while adding balloons display value in}) { } $WSMCONF {." "e11"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\" } (Gettext {occurred while adding balloons display value in}) { } $WSMCONF {." "e11"}
                   Quit
                End
             End
@@ -578,7 +578,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\" } (Gettext {emerged while changing balloons display value in}) { } $WSMCONF {." "e12"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\" } (Gettext {occurred while changing balloons display value in}) { } $WSMCONF {." "e12"}
                   Quit
                End
             End
@@ -596,7 +596,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\" } (Gettext {emerged while adding skip list value in}) { } $WSMCONF {." "e13"}
+                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\" } (Gettext {occurred while adding skip list value in}) { } $WSMCONF {." "e13"}
                   Quit
                End
             End
@@ -608,7 +608,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\" } (Gettext {emerged while changing skip list value in}) { } $WSMCONF {." "e14"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\" } (Gettext {occurred while changing skip list value in}) { } $WSMCONF {." "e14"}
                   Quit
                End
             End
@@ -626,7 +626,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\" } (Gettext {emerged while appending window content type value in}) { } $WSMCONF {." "e15"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\" } (Gettext {occurred while appending window content type value in}) { } $WSMCONF {." "e15"}
                   Quit
                End
             End
@@ -638,7 +638,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\" } (Gettext {emerged while changing window content type value in}) { } $WSMCONF {." "e16"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\" } (Gettext {occurred while changing window content type value in}) { } $WSMCONF {." "e16"}
                   Quit
                End
             End
@@ -886,4 +886,3 @@ Widget 20
          Do {f_DisplayURL "$[gt.GWM]" html/NsCDE-GWM.html}
       End
 End
-

--- a/lib/scripts/ModifyColor
+++ b/lib/scripts/ModifyColor
@@ -174,7 +174,7 @@ Widget 5
          End
          Else
          Begin
-            Do {f_Notifier "Color Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error occured while calling Color Selector:] \\\"} $GrabHEX {\\\"}
+            Do {f_Notifier "Color Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error occurred while calling Color Selector:] \\\"} $GrabHEX {\\\"}
          End
       End
 End
@@ -529,4 +529,3 @@ Widget 23
          Do {f_DisplayURL "$[gt.Color Style Manager]" html/NsCDE-ColorMgr.html}
       End
 End
-

--- a/lib/scripts/NProcMgr
+++ b/lib/scripts/NProcMgr
@@ -5,7 +5,7 @@
 #
 
 UseGettext {$NSCDE_ROOT/share/locale;NsCDE-NProcMgr}
-WindowLocaleTitle { NsCDE Proces Management }
+WindowLocaleTitle { NsCDE Process Management }
 WindowSize 502 732
 Colorset 22
 
@@ -489,7 +489,7 @@ Property
    Position 20 272
    Type CheckBox
    Flags NoReliefString
-   Title {FvwmAnimate}
+   Title {Fvwm Animate}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -852,7 +852,7 @@ Widget 40
    Position 210 81
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -867,7 +867,7 @@ Widget 41
    Position 210 121
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -882,7 +882,7 @@ Widget 42
    Position 210 157
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -897,7 +897,7 @@ Widget 43
    Position 210 195
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -912,7 +912,7 @@ Widget 44
    Position 210 233
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -927,7 +927,7 @@ Widget 45
    Position 210 271
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -942,7 +942,7 @@ Widget 46
    Position 210 309
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -957,7 +957,7 @@ Widget 47
    Position 210 347
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -972,7 +972,7 @@ Widget 48
    Position 210 385
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -987,7 +987,7 @@ Widget 49
    Position 210 423
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1002,7 +1002,7 @@ Widget 60
    Position 210 461
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1017,7 +1017,7 @@ Widget 61
    Position 210 500
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1337,4 +1337,3 @@ Property
          Do {f_DisplayURL "$[gt.NsCDE Process Manager]" html/NsCDE-NProcMgr.html}
       End
 End
-

--- a/lib/scripts/SubpanelMgr
+++ b/lib/scripts/SubpanelMgr
@@ -733,7 +733,7 @@ Widget 18
    Flags NoReliefString Left
    Value 0
    Colorset 22
-   Title { Do not check for command existance}
+   Title { Do not check whether the command exists}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -899,4 +899,3 @@ Widget 25
          End
       End
 End
-

--- a/lib/scripts/WsPgMgr
+++ b/lib/scripts/WsPgMgr
@@ -20,7 +20,7 @@ Begin
    If $DeskNo == {} Then
    Begin
       Do {None ("Workspaces and Pages Style Manager Warning")}
-          { f_Notifier "Workspaces and Pages Syle Manager Warning" "Dismiss" "NsCDE/Warning.xpm"}
+          { f_Notifier "Workspaces and Pages Style Manager Warning" "Dismiss" "NsCDE/Warning.xpm"}
           { "Warning: Number of Workspaces and/or number of Pages are not set. Using 4 as default."}
 
       Set $DeskNo = 4
@@ -944,7 +944,7 @@ Widget 21
  
          If $DStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -968,7 +968,7 @@ Widget 21
  
          If $PVStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -991,7 +991,7 @@ Widget 21
          End
          If $PHStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -1014,7 +1014,7 @@ Widget 21
          End
          If $WSMECOStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $WSMECOStringToCheck == 1 Then
@@ -1050,7 +1050,7 @@ Widget 21
          End
          If $DskConfStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $DskConfStringToCheck == 1 Then
@@ -1328,4 +1328,3 @@ Widget 25
          ChangeColorset 24 20
       End
 End
-

--- a/nscde_tools/FvwmScripts/GWM.in
+++ b/nscde_tools/FvwmScripts/GWM.in
@@ -15,7 +15,7 @@ prepare_piperead=0
 
 function usage
 {
-   echo "Usage: ${0##*/} -w <vp width> -h <vp height> -f <reduction factor> -d <no of desks> [ -c <pager conf file> ] [ -s ] | [ -H ]"
+   echo "Usage: ${0##*/} -w <viewport width> -h <viewport height> -f <reduction factor> -d <number of desks> [ -c <pager configuration file> ] [ -s ] | [ -H ]"
    exit $1
 }
 
@@ -770,4 +770,3 @@ fi
 if (($write_gwm_script == 1)); then
    WriteGwmScript
 fi
-

--- a/nscde_tools/FvwmScripts/Notifier.in
+++ b/nscde_tools/FvwmScripts/Notifier.in
@@ -11,7 +11,7 @@ IFS=" "
 
 function usage
 {
-   echo "Usage: ${0##*/} -t <title> -b <buttontitle> -i <icon> [ -s <textstr> | -f <file> ] [ -l <catalog name> ] [ -h ]"
+   echo "Usage: ${0##*/} -t <title> -b <button title> -i <icon> [ -s <text> | -f <file> ] [ -l <catalog name> ] [ -h ]"
    exit $1
 }
 
@@ -251,4 +251,3 @@ Widget 3
 End
 
 EOF
-

--- a/nscde_tools/FvwmScripts/Splash.in
+++ b/nscde_tools/FvwmScripts/Splash.in
@@ -125,7 +125,7 @@ Begin
 
    ChangeLocaleTitle 5 \$VarTitle1
    ChangeLocaleTitle 6 \$VarTitle2
-   ChangeLocaleTitle 7 { NsCDE is a Free Software released under GPLv3 licence.}
+   ChangeLocaleTitle 7 { NsCDE is Free Software released under the GPLv3 licence.}
    ChangeLocaleTitle 8 \$VarTitle3
 End
 
@@ -240,7 +240,7 @@ Widget 7
    Type ItemDraw
    Flags NoReliefString Left
    Colorset 52
-   LocaleTitle {NsCDE is a Free Software released under GPLv3 licence.}
+   LocaleTitle {NsCDE is Free Software released under the GPLv3 licence.}
    Main
       Case message of
       SingleClic :
@@ -324,4 +324,3 @@ Widget 9
       Begin
       End
 End
-

--- a/nscde_tools/acpimgr.in
+++ b/nscde_tools/acpimgr.in
@@ -53,7 +53,7 @@ elif [ "$OS" == "OpenBSD" ]; then
 else
    Opmode=$2
    if [ "x$Opmode" == "x" ]; then
-      echo "Error: Unknown ACPI operation mode."
+      echo "Error: unknown ACPI operation mode."
       exit 4
    fi
 fi
@@ -86,7 +86,7 @@ function hibernate
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: Hibernate to disk is not supported on NetBSD."
+      echo "Notice: hibernation to disk is not supported on NetBSD."
    elif [ "$Opmode" == "openbsd" ]; then
       /usr/sbin/apm -Z
    fi
@@ -99,13 +99,13 @@ function hybrid_suspend
    elif [ "$Opmode" == "systemd" ]; then
       systemctl hybrid-sleep -i
    elif [ "$Opmode" == "acpiconf" ]; then
-      echo "Not available on $OS" >&2
+      echo "Not available on $OS." >&2
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: Hybrid suspend is not supported on NetBSD."
+      echo "Notice: hybrid suspend is not supported on NetBSD."
    elif [ "$Opmode" == "openbsd" ]; then
-      echo "Notice: Hybrid suspend is not supported on OpenBSD."
+      echo "Notice: hybrid suspend is not supported on OpenBSD."
    fi
 }
 
@@ -182,4 +182,3 @@ case $Action in
       usage
    ;;
 esac
-

--- a/nscde_tools/backdropmgr.in
+++ b/nscde_tools/backdropmgr.in
@@ -7,7 +7,7 @@
 #
 
 # NsCDE: colormgr shell script
-# BackdropMgr FvwmScript backgroud worker
+# BackdropMgr FvwmScript background worker
 
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
@@ -20,7 +20,7 @@ EchoInfo=0
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot source ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
    exit 1
 fi
 
@@ -163,7 +163,7 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: convert of photo $PhotoNamePath did not suceeded."
+               echo "Error: could not convert photo $PhotoNamePath."
             fi
             OldBackdrop=$(egrep "Colorset 3${Desk}( bg ${bgcs},)? (Tiled|Aspect)?Pixmap (.*)" "${FVWM_USERDIR}/Backdrops.fvwmgen")
             sededpath=$(echo "$ConvertedPhoto" | sed 's/\//\\\//g')
@@ -172,7 +172,7 @@ function GeneratePhotoPreview
                rm -f "${FVWM_USERDIR}/backer/${OldBackdrop##*/}"
             fi
          else
-            echo "Error getting image path for $1."
+            echo "Error: could not get the image path for $1."
          fi
       else
          if [ -s "$PhotoNamePath" ]; then
@@ -184,12 +184,12 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: convert of photo $PhotoNamePath did not suceeded."
+               echo "Error: could not convert photo $PhotoNamePath."
             fi
             bgcs_clean=$(echo "${bgcs}" | sed 's/\\//g')
             echo "Colorset 3${Desk} bg ${bgcs_clean}, $PixmapVariant $ConvertedPhoto" >> ${FVWM_USERDIR}/Backdrops.fvwmgen
          else
-            echo "Error getting image path for $1."
+            echo "Error: could not get the image path for $1."
          fi
       fi
 

--- a/nscde_tools/bootstrap.in
+++ b/nscde_tools/bootstrap.in
@@ -801,14 +801,14 @@ function setup_nscde
    fi
 
    locale_terminal_program_in=$(gettext -s "terminal program in")
-   locale_or_leave_autodiscovery=$(gettext -s "or leave autodiscovery")
+   locale_or_leave_autodiscovery=$(gettext -s "or leave autodiscovery.")
    locale_Hint_See=$(gettext -s "Hint: See")
    locale_for_Gkrellm_X_session_and=$(gettext -s "for Gkrellm, X session and")
    sleep 1
    gettext -s '... done!'
    echo ""
    gettext -s "You can set \$[infostore.terminal] variable to your favorite"
-   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf ${locale_or_leave_autodiscovery}."
+   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf ${locale_or_leave_autodiscovery}"
    echo ""
    echo "$locale_Hint_See $NSCDE_DATADIR/examples $locale_for_Gkrellm_X_session_and"
    gettext -s "other integration options you may want to apply."
@@ -848,4 +848,3 @@ do
    ;;
    esac
 done
-

--- a/nscde_tools/chtheme.in
+++ b/nscde_tools/chtheme.in
@@ -232,7 +232,7 @@ function localsetup
 
 function Usage
 {
-   echo "Usage: ${BaseName} [ -p <Palette Name> ] [ -n <No of Colors> ] [ -5 | -8 ] [ -w ] [ -m ]"
+   echo "Usage: ${BaseName} [ -p <palette name> ] [ -n <number of colors> ] [ -5 | -8 ] [ -w ] [ -m ]"
    echo "               [ -b ] [ -x ] [ -g <gtk2|False,gtk3|False,gtk4|False> ] [ -q qt4,qt5g|qt5k,qt6 ]"
    echo "               [ -l ] [ -r ] [ -R ] [ -h ]"
 
@@ -308,7 +308,7 @@ do
          palette_name="$OPTARG"
          palette_path=$($NSCDE_TOOLSDIR/colormgr -e -c $ncolors -g "$palette_name")
          if [ ! -r "$palette_path" ]; then
-            echo "Palette $palette_name was not found. Path: \"$palette_path\"."
+            echo "Palette $palette_name was not found at $palette_path."
             exit 9
          fi
       ;;
@@ -406,4 +406,3 @@ fi
 if [ "x$ncolors" == "x" ]; then
    Usage Err
 fi
-

--- a/nscde_tools/colorconv.in
+++ b/nscde_tools/colorconv.in
@@ -36,7 +36,7 @@ def rgb2hex(rgb1, rgb2, rgb3, x11_16_bit):
       print ('%01s%02x%02x%02x%02x%02x%02x' % ("#", rgb1, rgb1, rgb2, rgb2, rgb3, rgb3))
 
 def usage():
-    print ("colorcalc [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help")
+    print ("Usage: colorconv [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help")
 
 def main():
     try:
@@ -68,4 +68,3 @@ def main():
 # Action ...
 if __name__ == '__main__':
     main()
-

--- a/nscde_tools/colormgr.in
+++ b/nscde_tools/colormgr.in
@@ -7,7 +7,7 @@
 #
 
 # NsCDE: colormgr shell script
-# ColorMgr FvwmScript backgroud worker
+# ColorMgr FvwmScript background worker
 
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
@@ -22,7 +22,7 @@ WsmVariant=0
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot source ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
    exit 1
 fi
 
@@ -50,7 +50,7 @@ function GenFullPalette
 
       echo ${FVWM_USERDIR}/tmp/_fullpalette.xpm
    else
-      echo "Error: Cannot open ${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm"
+      echo "Error: cannot open ${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm."
       exit 3
    fi
 }
@@ -467,7 +467,7 @@ do
          if (($PreviewMode == 0)); then
             ProgBits
          else
-            echo "Not performing pixmap modification in preview mode."
+            echo "Pixmap modification is disabled in preview mode."
          fi
       ;;
       b)
@@ -481,4 +481,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/confget.in
+++ b/nscde_tools/confget.in
@@ -9,7 +9,7 @@
 import configparser, getopt, os, sys, re
 
 def usage():
-    print ("confget [ -c <file> [ -s <section> ] -k <key> [ -h ]")
+    print ("Usage: confget -c <file> [ -s <section> ] -k <key> [ -h ]")
 
 def cmdoptions():
     section = ''
@@ -75,4 +75,3 @@ def main ():
 if __name__ == '__main__':
     cmdoptions()
     main()
-

--- a/nscde_tools/confset.in
+++ b/nscde_tools/confset.in
@@ -9,7 +9,7 @@
 import configparser, getopt, os, sys, re
 
 def usage():
-    print ("confset [ -c <file> -t [ properties|ini ] [ -s <section> ] -k <key> -v <value> | [ -h ]")
+    print ("Usage: confset -c <file> [ -t <properties|ini> ] [ -s <section> ] -k <key> [ -v <value> | -r ] [ -h ]")
 
 def cmdoptions():
     section = ''
@@ -72,7 +72,7 @@ def main ():
                 parser.set(section, key, value)
         except configparser.NoSectionError:
             if not removekey:
-                print ("No section named " + section + " creating it.")
+                print ("Section " + section + " does not exist; creating it.")
                 parser.add_section(section)
                 parser.set(section, key, value)
 
@@ -99,7 +99,7 @@ def main ():
                             cff.write(dkey + '=' + val)
             cff.close()
         except:
-            print ("Cannot open file", conffile, "trying to create it.")
+            print ("Cannot open " + conffile + "; trying to create it.")
             fh = open(conffile, 'w')
             fh.write(key + ' = ' + value + '\n')
             fh.close()
@@ -108,4 +108,3 @@ def main ():
 if __name__ == '__main__':
     cmdoptions()
     main()
-

--- a/nscde_tools/fontmgr.in
+++ b/nscde_tools/fontmgr.in
@@ -18,7 +18,7 @@ fi
 
 type -p fc-list > /dev/null
 if (($? != 0)); then
-   echo "Error: fc-list command not found."
+   echo "Error: the fc-list command was not found."
    exit 3
 fi
 
@@ -31,12 +31,12 @@ FNUMS=$(echo "$FNAMES" | sort -u | grep -En '.*')
 function findfontsets
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -330,8 +330,7 @@ do
          miscintegrations
       ;;
       h)
-         echo "Usage: ..."
+         echo "Usage: ${0##*/} [ -pP ] [ -F <font-set number> ] [ -f <font-set name> ] [ -gGnN <value> ] [ -s <style> ] [ -rXmTQM <value> ] [ -h ]"
       ;;
    esac
 done
-

--- a/nscde_tools/fp_manage_subpanel.in
+++ b/nscde_tools/fp_manage_subpanel.in
@@ -1,39 +1,39 @@
 #!@KSH@
 
 if [ -z $HOME ]; then
-   echo "Error: HOME is not set cannot continue."
+   echo "Error: HOME is not set; cannot continue."
    exit 3
 fi
 
 if [ -z $NSCDE_ROOT ]; then
-   echo "Error: NSCDE_ROOT is not set cannot continue."
+   echo "Error: NSCDE_ROOT is not set; cannot continue."
    exit 4
 fi
 
 if [ ! -e "$NSCDE_ROOT" ]; then
-   echo "Error: NSCDE_ROOT does not exist. Cannot continue."
+   echo "Error: NSCDE_ROOT does not exist; cannot continue."
    exit 5
 fi
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "Error: NSCDE_DATADIR is not set cannot continue."
+   echo "Error: NSCDE_DATADIR is not set; cannot continue."
    exit 4
 fi
 
 if [ ! -e "$NSCDE_DATADIR" ]; then
-   echo "Error: NSCDE_DATADIR does not exist. Cannot continue."
+   echo "Error: NSCDE_DATADIR does not exist; cannot continue."
    exit 5
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "Error: FVWM_USERDIR is not set cannot continue."
+   echo "Error: FVWM_USERDIR is not set; cannot continue."
    exit 6
 fi
 
 function add_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "ERROR: Missing subpanel number."
+      echo "Error: missing subpanel number."
       exit 9
    fi
 
@@ -47,7 +47,7 @@ function add_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,0/S${SubpanelNo},ENABLED,1/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "ERROR: Cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
          exit 8
       fi
    fi
@@ -56,7 +56,7 @@ function add_subpanel
 function delete_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "ERROR: Missing subpanel number."
+      echo "Error: missing subpanel number."
       exit 9
    fi
 
@@ -70,7 +70,7 @@ function delete_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,1/S${SubpanelNo},ENABLED,0/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "ERROR: Cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
          exit 8
       fi
    fi
@@ -340,7 +340,7 @@ do
          SubpLocalDefCheck=$(egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED),.*" "$FVWM_USERDIR/Subpanels.actions" 2>/dev/null | wc -l)
 
          if (($SubpLocalDefCheck != 0)) && (($SubpLocalDefCheck != 3)); then
-            echo "ERROR: invalid configuration for subpanel ${SubpanelNo} in $FVWM_USERDIR/Subpanels.actions."
+            echo "Error: invalid configuration for subpanel ${SubpanelNo} in $FVWM_USERDIR/Subpanels.actions."
             exit 7
          fi
       ;;
@@ -374,4 +374,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/fpdoc.in
+++ b/nscde_tools/fpdoc.in
@@ -33,7 +33,7 @@ function find_cmd_in_subpanel
          exit 0
       fi
    else
-      echo "Error: ${0##*/}: Empty subpanel search for line ${LineInSubpanel} in subpanel ${SubpanelNo}"
+      echo "Error: ${0##*/}: no entry found for line ${LineInSubpanel} in subpanel ${SubpanelNo}."
       exit 1
    fi
 }
@@ -55,7 +55,7 @@ elif [ "$Mode" == "-rsubp" ]; then
    RawMan=1
    find_cmd_in_subpanel
 else
-   echo "Error: ${0##*/}: Unknown mode of operation."
+   echo "Error: ${0##*/}: unknown operation mode."
    exit 1
 fi
 
@@ -285,4 +285,3 @@ if (($MANRET != 0)); then
       fi
    fi
 fi
-

--- a/nscde_tools/generate_app_menus.in
+++ b/nscde_tools/generate_app_menus.in
@@ -46,8 +46,7 @@ if (($file_err == 0)); then
       curr_res="${res}"
    done
 else
-   echo "${0##*/}: No valid applications menus file found." >&2
+   echo "${0##*/}: no valid application-menu file was found." >&2
 fi
 
 echo "+ I InfoStoreRemove menuitem.clres"
-

--- a/nscde_tools/get_logical_screens.in
+++ b/nscde_tools/get_logical_screens.in
@@ -34,7 +34,7 @@ function defaultcf
 # Without xrandr(1) we cannot continue.
 type -qp xrandr
 if (($? != 0)); then
-   echo "${0##*/}: xrandr command is not available in PATH. Setting default one monitor setup." >&2
+   echo "${0##*/}: xrandr is not available in PATH; using a single-monitor setup." >&2
    defaultcf
    exit 0
 fi
@@ -46,7 +46,7 @@ mdata=$(xrandr --listmonitors)
 # for this Xinerama/SLS support.
 screencnt=$(echo "$xdata" | wc -l)
 if (($screencnt > 1)); then
-   echo "${0##*/}: More than one local screen handling is not yet tested and hence not supported." >&2
+   echo "${0##*/}: multiple local X screens are not currently supported." >&2
    defaultcf
    exit 0
 fi
@@ -81,7 +81,7 @@ if (($? == 0)); then
       echo "InfoStoreAdd lscrn.cnt $moncnt"
    fi
 else
-   echo "${0##*/}: Error in handling monitor count: \"$moncnt\""
+   echo "${0##*/}: invalid monitor count: $moncnt."
    defaultcf
    exit 0
 fi
@@ -133,7 +133,7 @@ do
          rootmenudata=$(@ECHONE@ "$rootmenudata\nAddToMenu m_SlsMoveAll \"Move To Logical Screen: &${scnum} ($[infostore.lscrn.${scrvar}.name]) ...\"           All MoveToScreen ${scrvar}")
       fi
    else
-      echo "${0##*/}: Error in handling monitor $mname width: (\"$scwidth\") or height (\"$scheight\")" >&2
+      echo "${0##*/}: invalid geometry for monitor $mname (width: $scwidth; height: $scheight)." >&2
       defaultcf
       break
    fi
@@ -216,4 +216,3 @@ if [ "x${check_fvwm3}" == "x1" ] ; then
       done < "$UserBackdropsFile"
    fi
 fi
-

--- a/nscde_tools/getfont.in
+++ b/nscde_tools/getfont.in
@@ -13,12 +13,12 @@ PrintFnSize=0
 PrettyName=0
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "No \$NSCDE_DATADIR set. Exiting."
+   echo "NSCDE_DATADIR is not set. Exiting."
    exit 3
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "No \$FVWM_USERDIR set. Exiting."
+   echo "FVWM_USERDIR is not set. Exiting."
    exit 4
 fi
 
@@ -62,7 +62,7 @@ function GetFont
          fncnffile="$FnFile"
          sysfncnffile="$FnFile"
       else
-         echo "Error: Cannot read $FnFile"
+         echo "Error: cannot read $FnFile."
          exit 3
       fi
    fi
@@ -204,7 +204,7 @@ do
          export FuncToCall="GetFontset"
       ;;
       h)
-         echo "Usage: ${0##*/} [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z maxsize ] [ -F ] [ -h ]"
+         echo "Usage: ${0##*/} [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z <maximum size> ] [ -F ] [ -h ]"
          exit 0
       ;;
    esac
@@ -215,4 +215,3 @@ if [ "x$FuncToCall" == "xGetFontset" ]; then
 else
    GetFont
 fi
-

--- a/nscde_tools/ised.in
+++ b/nscde_tools/ised.in
@@ -30,7 +30,7 @@ case $NSCDE_OS in
          if (($? == 0)); then
             SED="sed"
          else
-            echo "Error: ${0##*/}: Cannot find GNU sed."
+            echo "Error: ${0##*/}: cannot find GNU sed."
          exit 4
          fi
       fi
@@ -44,7 +44,7 @@ case $NSCDE_OS in
       if (($? == 0)); then
          SED="gsed"
       else
-         echo "Error: ${0##*/}: Cannot find GNU sed."
+         echo "Error: ${0##*/}: cannot find GNU sed."
          exit 4
       fi
    fi
@@ -67,7 +67,7 @@ do
       TO_STDOUT=1
    ;;
    h)
-      echo "Usage: ${0##*/} -s <sedopts> -c <sedcode> [ -f <inputfile> ] [ -h ]"
+      echo "Usage: ${0##*/} -s <sed options> -c <sed code> [ -f <input file> ] [ -h ]"
       exit 0
    ;;
    esac

--- a/nscde_tools/keymenu.in
+++ b/nscde_tools/keymenu.in
@@ -9,10 +9,10 @@
 KeybindingsType="$2"
 
 if [ "x${KeybindingsType}" == "x" ]; then
-   echo "NsCDE: KeybindingsType was empty, using default: cua." >&2
+   echo "NsCDE: KeybindingsType is empty; using the default: cua." >&2
    KeybindingsType="cucuaa"
 else
-   echo "NsCDE: Using KeybindingsType ${2}." >&2
+   echo "NsCDE: using KeybindingsType ${2}." >&2
 fi
 
 function config_for_menu
@@ -119,4 +119,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/palette_colorgen.in
+++ b/nscde_tools/palette_colorgen.in
@@ -729,7 +729,7 @@ def gencdecolors(palettefile,n,infile,outdir,fext,shorten_colorhex):
 
 
 def usage():
-    print ("Used to generate colorsets for fvwm, Xresources, backdrops and element pixmaps")
+    print ("Generate colorsets for FVWM, X resources, backdrops, and interface pixmaps.")
 
 def main():
     shorten_colorhex = 0
@@ -816,4 +816,3 @@ def main():
 # Action ...
 if __name__ == '__main__':
     main()
-

--- a/nscde_tools/style_managers.shlib.in
+++ b/nscde_tools/style_managers.shlib.in
@@ -5,19 +5,19 @@
 #
 
 # NsCDE: routines common for Style Managers ColorMgr and BackdropMgr
-# FvwmScript backgroud workers
+# FvwmScript background workers
 
 # Scans system and user path for palettes and stores them in SysPalettes and UserPalettes variables
 # Used in other API functions and in managers
 function FindPalettes
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -36,12 +36,12 @@ function FindPalettes
 function FindBackdrops
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -60,12 +60,12 @@ function FindBackdrops
 function FindPhotos
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -240,4 +240,3 @@ function GetPaletteByName
       fi
    done
 }
-

--- a/nscde_tools/subpanel_menuitem_props.in
+++ b/nscde_tools/subpanel_menuitem_props.in
@@ -64,14 +64,14 @@ function subpanels_file_tstamp
    REGEN=0
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]; then
-         echo "File $FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen ... regenerating last one." >&2
+         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen; regenerating the latter." >&2
          $NSCDE_TOOLSDIR/generate_subpanels -w > $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen
          REGEN=1
       fi
    fi
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]; then
-         echo "File $FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen ... regenerating last one." >&2
+         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen; regenerating the latter." >&2
          $NSCDE_TOOLSDIR/generate_subpanels -f > $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen
          REGEN=1
       fi
@@ -301,14 +301,14 @@ function manage_entry
             $NSCDE_ROOT/bin/nscde_fvwmclnt "f_Notifier \"Subpanel Properties\" \"Dismiss\" \"NsCDE/Error.xpm\" \
                         \"$[gt.Action for item] '$TITLE' $[gt.not performed on Subpanel] $subpid. $[gt.Errors found in] $tmpfile.\""
          else
-            echo "Action for item $TITLE not performed on Subpanel $subpid. Errors in $tmpfile found." >&2
+            echo "Action for item $TITLE was not performed on subpanel $subpid; errors were written to $tmpfile." >&2
          fi
          exit 2
       fi
    fi
 
    if [ -f "$tmpfile" ]; then
-      echo "Removing stale tmp file $tmpfile" >&2
+      echo "Removing stale temporary file $tmpfile." >&2
       rm -f "$tmpfile"
    fi
 }
@@ -406,7 +406,7 @@ function copy_to_main_panel
       entry_to_copy=$(egrep -h "^S${subpid},ENTRY,*" "$NSCDE_DATADIR/defaults/Subpanels.actions" | sed -n "${entryid}p")
    fi
    if [ "x$entry_to_copy" == "x" ]; then
-      echo "ERROR: subpanel_menuitem_props (copy_to_main_panel): internal error. No entry in system Subpanels.actons file."
+      echo "Error: subpanel_menuitem_props (copy_to_main_panel): no entry in the system Subpanels.actions file."
       exit 10
    fi
    echo "$entry_to_copy" | tail -1 | while IFS="," read smark emark title type icon cmd
@@ -414,7 +414,7 @@ function copy_to_main_panel
       for content in "$title" "$icon" "$cmd"
       do
          if [ "x$content" == "x" ]; then
-            echo "ERROR: subpanel_menuitem_props (copy_to_main_panel): empty title, icon or command definition."
+            echo "Error: subpanel_menuitem_props (copy_to_main_panel): the title, icon, or command is empty."
             exit 10
          fi
       done
@@ -441,7 +441,7 @@ function copy_to_main_panel
 
       # Try find_appropriate_icon with different extensions.
       if (($ENOICON == 1)); then
-         echo "Trying heuristics with icon extension formats while searching for an icon ..."
+         echo "Trying alternate file extensions while searching for an icon ..."
          export ENOICON=0
          case "$icon_ext" in
          'png')
@@ -744,4 +744,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/themegen.in
+++ b/nscde_tools/themegen.in
@@ -12,14 +12,14 @@ import shutil
 
 nscde_libdir = os.environ.get('NSCDE_LIBDIR')
 if not nscde_libdir:
-   sys.stderr.write("NSCDE_LIBDIR not set. Stop.\n")
+   sys.stderr.write("NSCDE_LIBDIR is not set. Stopping.\n")
    sys.exit(1)
 else:
    sys.path.append(nscde_libdir + "/python")
 
 nscde_datadir = os.environ.get('NSCDE_DATADIR')
 if not nscde_datadir:
-   sys.stderr.write("NSCDE_DATADIR not defined. Stop.\n")
+   sys.stderr.write("NSCDE_DATADIR is not defined. Stopping.\n")
    sys.exit(1)
 
 themegen="""
@@ -42,7 +42,7 @@ from Opts import Opts
 from MotifColors import readMotifColors2
 
 helptxt="""Generate GTK2 and GTK3 theme in style of CDE/Motif
-Directory 'NsCDE' will be be created as ~/.themes/NsCDE
+Directory 'NsCDE' will be created as ~/.themes/NsCDE
 
 Usage:
    themegen <palettename> ncolors gtk2 gtk3
@@ -116,4 +116,3 @@ theme=Theme(opts)
 Globals.colorshash=readMotifColors2(opts.ncolors,opts.currentpalettefile)
 theme.initTheme()
 theme.updateThemeNow()
-

--- a/nscde_tools/var_append.in
+++ b/nscde_tools/var_append.in
@@ -19,7 +19,7 @@ eval varcontent='$'$varname
 for argv in "$valsep" "$varname" "$varnewval"
 do
    if [ "x$argv" == "x" ]; then
-      echo "Usage: ${0##*/} <separator> <varname> <varvalue>" >&2
+      echo "Usage: ${0##*/} <separator> <variable name> <variable value>" >&2
       if [ "x$varname" != "x" ]; then
          echo "$varcontent"
       fi

--- a/nscde_tools/xdowrapper.in
+++ b/nscde_tools/xdowrapper.in
@@ -11,7 +11,7 @@
 
 type -qp xdotool
 if (($? != 0)); then
-   echo "No xdotool found. Exiting." >&2
+   echo "xdotool was not found. Exiting." >&2
    exit 1
 fi
 
@@ -49,4 +49,3 @@ do
 
    (( cnt = cnt + 1 ))
 done
-

--- a/po/NsCDE-GWM.hr.po
+++ b/po/NsCDE-GWM.hr.po
@@ -119,51 +119,50 @@ msgstr "Greška Grafičkog Radnopovršinskog Upravljača"
 msgid "Error"
 msgstr "Greška"
 
-msgid "emerged while appending backdrops value in"
+msgid "occurred while appending backdrops value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti pozadine u"
 
-msgid "emerged while changing backdrops value in"
+msgid "occurred while changing backdrops value in"
 msgstr "se pojavila prilikom promjene vrijednosti pozadine u"
 
-msgid "emerged while appending highlight value in"
+msgid "occurred while appending highlight value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti osvjetljenja u"
 
-msgid "emerged while changing highlight value in"
+msgid "occurred while changing highlight value in"
 msgstr "se pojavila prilikom promjene vrijednosti osvjetljenja u"
 
-msgid "emerged while appending workspace name label value in"
+msgid "occurred while appending workspace name label value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti oznake radne površine u"
 
-msgid "emerged while changing workspace name label value in"
+msgid "occurred while changing workspace name label value in"
 msgstr "se pojavila prilikom promjene vrijednosti oznake radne površine u"
 
-msgid "emerged while appending GWM rows value in"
+msgid "occurred while appending GWM rows value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti GWM redaka u"
 
-msgid "emerged while changing GWM rows value in"
+msgid "occurred while changing GWM rows value in"
 msgstr "se pojavila prilikom promjene vrijednosti GWM redaka u"
 
-msgid "emerged while adding GWM width scale value in"
+msgid "occurred while adding GWM width scale value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti GWM širine opsega u"
 
-msgid "emerged while changing GWM width scale value in"
+msgid "occurred while changing GWM width scale value in"
 msgstr "se pojavila prilikom promjene vrijednosti GWM širine opsega u"
 
-msgid "emerged while adding balloons display value in"
+msgid "occurred while adding balloons display value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti prikaza balona u"
 
-msgid "emerged while changing balloons display value in"
+msgid "occurred while changing balloons display value in"
 msgstr "se pojavila prilikom promjene vrijednosti prikaza balona u"
 
-msgid "emerged while adding skip list value in"
+msgid "occurred while adding skip list value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti prozorske liste izostavljanja u"
 
-msgid "emerged while changing skip list value in"
+msgid "occurred while changing skip list value in"
 msgstr "se pojavila prilikom promjene vrijednosti prozorske liste izostavljanja u"
 
-msgid "emerged while appending window content type value in"
+msgid "occurred while appending window content type value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti tipa sadržaja prozora u"
 
-msgid "emerged while changing window content type value in"
+msgid "occurred while changing window content type value in"
 msgstr "se pojavila prilikom promjene vrijednosti tipa sadržaja prozora u"
-

--- a/po/NsCDE-Subpanel.hr.po
+++ b/po/NsCDE-Subpanel.hr.po
@@ -49,7 +49,7 @@ msgstr "Komanda:"
 msgid "Icon File:"
 msgstr "Datoteka s Ikonom"
 
-msgid " Do not check for command existance"
+msgid " Do not check whether the command exists"
 msgstr " Ne provjeravaj da li komanda postoji"
 
 msgid "Apply"
@@ -93,4 +93,3 @@ msgstr "U Redu"
 
 msgid "Close"
 msgstr "Zatvori"
-

--- a/po/NsCDE.hr.po
+++ b/po/NsCDE.hr.po
@@ -837,7 +837,7 @@ msgstr "Greška prilikom stvaranja"
 msgid "Error"
 msgstr "Greška"
 
-msgid "occured while checking config file"
+msgid "occurred while checking config file"
 msgstr "se dogodila prilikom provjeravanja konfiguracijske datoteke"
 
 msgid "Screenshot Function Error"
@@ -905,7 +905,7 @@ msgstr "Ime Postave fonta mora biti definirano prije pohrane!"
 msgid "Not all applications have the ability to dynamically change their font. Such applications may have to be restarted for effect to take place."
 msgstr "Nemaju sve aplikacije mogućnost dinamički promijeniti svoj font. Takve aplikacije će možda morati biti restartane da bi došlo do efekta."
 
-msgid "Error occured while calling Color Selector:"
+msgid "Error occurred while calling Color Selector:"
 msgstr "Dogodila se greška prilikom pozivanja Odabiratelja Boja:"
 
 msgid "ERROR: Old value of FP.LeftLaunchersNum is not a number:"
@@ -1390,4 +1390,3 @@ msgstr "Pomoć za Dijalog Sistemske Akcije"
 
 msgid "System Information Help"
 msgstr "Pomoć za Sistemske Informacije"
-

--- a/po/nscde-bootstrap.hr.po
+++ b/po/nscde-bootstrap.hr.po
@@ -253,7 +253,7 @@ msgstr "Možete postaviti $[infostore.terminal] varijablu na vaš omiljeni"
 msgid "terminal program in"
 msgstr "terminalski program u"
 
-msgid "or leave autodiscovery"
+msgid "or leave autodiscovery."
 msgstr "ili ostavite automatsko otkrivanje"
 
 msgid "Hint: See"
@@ -285,4 +285,3 @@ msgstr "Instalira se zadana rofi config datoteka kao "
 
 msgid "Backing up pre-NsCDE GTK and Qt config files as "
 msgstr "Kreiram pre-NsCDE kopiju GTK i Qt konfiguracija kao "
-


### PR DESCRIPTION
## Summary

This is part 1 of a three-PR series that fully enables Simplified Chinese localization.

- Correct user-facing English grammar, spelling, punctuation, and terminology.
- Clarify helper-tool diagnostics and usage text.
- Keep affected Croatian gettext entries synchronized with the corrected source strings.

No functional behavior change is intended.

## Why this is separate

English source strings are also gettext keys. Correcting them first gives every catalog stable source text and keeps language-neutral editorial changes separate from localization infrastructure and Chinese translations.

## Series

1. **English corrections and typos** — this PR
2. Localization infrastructure — #236
3. Complete Simplified Chinese localization — #237

These PRs must be merged in order.

## Scope

- 2 focused, signed commits
- 41 affected files
- 161 additions and 200 deletions
- 2 commits ahead of and 0 commits behind upstream `master`
