### PR TITLE
[2/3] i18n: make runtime messages localizable

### DIFF
--- a/bin/nscde.in
+++ b/bin/nscde.in
@@ -8,9 +8,22 @@
 
 # Main starting wrapper
 
+TEXTDOMAINDIR="@NSCDE_DATADIR@/../locale"
+TEXTDOMAIN="NsCDE"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Basic sanity check.
 if [ -z $HOME ]; then
-   echo "Error: HOME is not set." >&2
+   printf '%s\n' "$(nscde_gettext 'Error: HOME is not set.')" >&2
    exit 2
 else
    export NSCDE_VERSION="@VERSION@"
@@ -18,7 +31,7 @@ fi
 
 # Either print version and exit, or construct main options for and output
 if [ "$1" == "-V" ]; then
-   echo "NsCDE Version $NSCDE_VERSION"
+   printf "$(nscde_gettext 'NsCDE Version %s')\n" "$NSCDE_VERSION"
    exit 0
 elif [ "$1" == "-v" ]; then
    echo "$NSCDE_VERSION"
@@ -35,7 +48,7 @@ echo "${DpiInfo}" | egrep -q "^[[:digit:]]+x[[:digit:]]+$"
 if (($? == 0)); then
    export DPI="${DpiInfo##*x}"
 else
-   echo "Warning: DPI value $DPI is not a valid X DPI specification; using 96 instead."
+   printf "$(nscde_gettext 'Warning: DPI value %s is not a valid X DPI specification; using 96 instead.')\n" "$DpiInfo"
    export DPI=96
 fi
 
@@ -70,7 +83,7 @@ if [ "x$FVWM_BIN" == "x" ]; then
    done
 fi
 if [ "x$FVWM_BIN" == "x" ]; then
-   echo "Error: none of fvwm, fvwm2, or fvwm3 was found in $PATH, and FVWM_BIN is not set. Exiting."
+   printf "$(nscde_gettext 'Error: none of fvwm, fvwm2, or fvwm3 was found in %s, and FVWM_BIN is not set. Exiting.')\n" "$PATH"
    exit 3
 fi
 
@@ -81,17 +94,17 @@ if [ -r "${FVWM_USERDIR}/Xdefaults" ]; then
    if (($? == 0)); then
       xrdb -remove && xrdb -cpp /usr/bin/cpp < ${FVWM_USERDIR}/Xdefaults
    else
-      echo "Warning: xrdb or cpp was not found in ${PATH}; ${FVWM_USERDIR}/Xdefaults will not be processed."
+      printf "$(nscde_gettext 'Warning: xrdb or cpp was not found in %s; %s will not be processed.')\n" "$PATH" "${FVWM_USERDIR}/Xdefaults"
    fi
 else
-   echo "Warning: cannot read ${FVWM_USERDIR}/Xdefaults."
+   printf "$(nscde_gettext 'Warning: cannot read %s.')\n" "${FVWM_USERDIR}/Xdefaults"
 fi
 
 # Handle our app-defaults dir if it exists.
 if [ -d "${FVWM_USERDIR}/app-defaults" ]; then
    export XAPPLRESDIR="${FVWM_USERDIR}/app-defaults"
 else
-   echo "Warning: directory ${FVWM_USERDIR}/app-defaults was not found."
+   printf "$(nscde_gettext 'Warning: directory %s was not found.')\n" "${FVWM_USERDIR}/app-defaults"
 fi
 
 # Set xset(1), setxkbmap(1), xgamma(1), xmodmap(1) and such things from
@@ -99,7 +112,7 @@ fi
 if [ -r "${FVWM_USERDIR}/Xset.conf" ]; then
    . "${FVWM_USERDIR}/Xset.conf"
 else
-   echo "Notice: ${FVWM_USERDIR}/Xset.conf does not exist."
+   printf "$(nscde_gettext 'Notice: %s does not exist.')\n" "${FVWM_USERDIR}/Xset.conf"
 fi
 
 # Early user customizations if needed can be set here.

--- a/bin/nscde.in
+++ b/bin/nscde.in
@@ -10,7 +10,7 @@
 
 # Basic sanity check.
 if [ -z $HOME ]; then
-   echo "Error: HOME not set." >&2
+   echo "Error: HOME is not set." >&2
    exit 2
 else
    export NSCDE_VERSION="@VERSION@"
@@ -35,7 +35,7 @@ echo "${DpiInfo}" | egrep -q "^[[:digit:]]+x[[:digit:]]+$"
 if (($? == 0)); then
    export DPI="${DpiInfo##*x}"
 else
-   echo "Warning: DPI \"$DPI\" is not recognized as X DPI specification. Setting DPI to 96"
+   echo "Warning: DPI value $DPI is not a valid X DPI specification; using 96 instead."
    export DPI=96
 fi
 
@@ -70,8 +70,7 @@ if [ "x$FVWM_BIN" == "x" ]; then
    done
 fi
 if [ "x$FVWM_BIN" == "x" ]; then
-   echo "Error: cannot detect niether fvwm, fvwm2 nor fvwm3 in $PATH and"
-   echo "environment variable FVWM_BIN is not set. Exiting."
+   echo "Error: none of fvwm, fvwm2, or fvwm3 was found in $PATH, and FVWM_BIN is not set. Exiting."
    exit 3
 fi
 
@@ -82,17 +81,17 @@ if [ -r "${FVWM_USERDIR}/Xdefaults" ]; then
    if (($? == 0)); then
       xrdb -remove && xrdb -cpp /usr/bin/cpp < ${FVWM_USERDIR}/Xdefaults
    else
-      echo "Warning: cannot find xrdb or cpp in ${PATH}, ${FVWM_USERDIR}/Xdefaults will not be processed"
+      echo "Warning: xrdb or cpp was not found in ${PATH}; ${FVWM_USERDIR}/Xdefaults will not be processed."
    fi
 else
-   echo "Warning: cannot read ${FVWM_USERDIR}/Xdefaults file"
+   echo "Warning: cannot read ${FVWM_USERDIR}/Xdefaults."
 fi
 
 # Handle our app-defaults dir if it exists.
 if [ -d "${FVWM_USERDIR}/app-defaults" ]; then
    export XAPPLRESDIR="${FVWM_USERDIR}/app-defaults"
 else
-   echo "Warning: cannot find ${FVWM_USERDIR}/app-defaults directory"
+   echo "Warning: directory ${FVWM_USERDIR}/app-defaults was not found."
 fi
 
 # Set xset(1), setxkbmap(1), xgamma(1), xmodmap(1) and such things from
@@ -100,7 +99,7 @@ fi
 if [ -r "${FVWM_USERDIR}/Xset.conf" ]; then
    . "${FVWM_USERDIR}/Xset.conf"
 else
-   echo "Notice: ${FVWM_USERDIR}/Xset.conf does not exist"
+   echo "Notice: ${FVWM_USERDIR}/Xset.conf does not exist."
 fi
 
 # Early user customizations if needed can be set here.
@@ -119,4 +118,3 @@ fi
 # Do not be picky if there is some failure left.
 # Do the best effort and exit always with 0.
 exit 0
-

--- a/bin/nscde_fvwmclnt.in
+++ b/bin/nscde_fvwmclnt.in
@@ -14,6 +14,19 @@
 # fvwm2 with fvwm2 as binary name
 # fallback if found
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="NsCDE"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Check if NsCDE FVWM_BIN is set, and try to find FvwmCommand in the same directory.
 if [ "x$FVWM_BIN" != "x" ]; then
    FVWM_BASE=${FVWM_BIN%/*}
@@ -50,5 +63,5 @@ fi
 if [ "x$FVWM_CLNT" != "x" ]; then
    exec $FVWM_CLNT "$@"
 else
-   echo "Error: cannot find a suitable FvwmCommand for this setup." >&2
+   printf '%s\n' "$(nscde_gettext 'Error: cannot find a suitable FvwmCommand for this setup.')" >&2
 fi

--- a/bin/nscde_fvwmclnt.in
+++ b/bin/nscde_fvwmclnt.in
@@ -50,6 +50,5 @@ fi
 if [ "x$FVWM_CLNT" != "x" ]; then
    exec $FVWM_CLNT "$@"
 else
-   echo "ERROR: Cannot find suitable FvwmCommand for your setup." >&2
+   echo "Error: cannot find a suitable FvwmCommand for this setup." >&2
 fi
-

--- a/data/fvwm/Functions.fvwmconf.in
+++ b/data/fvwm/Functions.fvwmconf.in
@@ -1180,7 +1180,7 @@ DestroyFunc f_Xscreensaver
 AddToFunc f_Xscreensaver
 + I Test (!x xscreensaver-command) None ("NsCDE-Notifier.f_Xscreensaver_1") f_Notifier \
     "Screensaver Error" "Dismiss" "NsCDE/Error.xpm" \
-    "$[gt.Cannot find] \\\"xscreensaver-command\\\" $[gt.in PATH] $[PATH]." "f_Xscreensaver_1"
+    "$[gt.Cannot find] \\\"xscreensaver-command\\\"$[gt. in PATH:] $[PATH]" "f_Xscreensaver_1"
 + I TestRc (Match) Break
 + I Test (!EnvMatch infostore.nscde_use_xscreensaver 1) None ("NsCDE-Notifier.f_Xscreensaver_2") f_Notifier \
     "Screensaver Error" "Dismiss" "NsCDE/Error.xpm" \
@@ -2149,10 +2149,10 @@ AddToFunc f_CheckMail
 + I Test (!EnvMatch infostore.mailreader *NOAPP*) Exec exec $[infostore.mailreader]
 + I Test (EnvMatch infostore.mailreader *NOAPP*) None ("NsCDE-Notifier.f_CheckMail") f_Notifier \
     "Check Mail Function" "Dismiss" "NsCDE/Info.xpm" \
-    "$[gt.Default E-mail application is not set. You can set] \$\[infostore.mailreader\] $[gt.in your] $[FVWM_USERDIR]/NsCDE.conf\
- $[gt.file and it will be called when e-mail icon is clicked. For visual letter icon notifications to work, a FVWM function\
- called] \\\"f_CheckMail\\\" $[gt.must be enabled and edited in your] $[FVWM_USERDIR]/Functions.fvwmlocal\
- $[gt.file. See the documentation for ideas how to set up personal e-mail notifications.]" "f_CheckMail"
+    "$[gt.Default E-mail application is not set. You can set] \$\[infostore.mailreader\]$[gt. in your] $[FVWM_USERDIR]/NsCDE.conf\
+$[gt. file and it will be called when e-mail icon is clicked. For visual letter icon notifications to work, a FVWM function\
+ called] \\\"f_CheckMail\\\"$[gt. must be enabled and edited in your] $[FVWM_USERDIR]/Functions.fvwmlocal\
+$[gt. file. See the documentation for ideas how to set up personal e-mail notifications.]" "f_CheckMail"
 
 # Called from MonthDayApplet (right of the watch on Front Panel)
 DestroyFunc f_Calendar
@@ -2161,7 +2161,7 @@ AddToFunc f_Calendar
  "Calendar Function" "Dismiss" "NsCDE/Info.xpm" \
  "$[gt.Default action is not set. If you wish to call some application when calendar icon is clicked, you must enable and edit]\
  \\\"f_Calendar\\\" $[gt.FVWM function in your] $[FVWM_USERDIR]/Functions.fvwmlocal\
- $[gt.file. See the documentation for ideas how to set that up.]
+$[gt. file. See the documentation for ideas how to set that up.]
 
 # Currently unused.
 DestroyFunc f_Mixer
@@ -2515,4 +2515,3 @@ AddToFunc f_Upgrade_1x_to_2x
 + I Test (!EnvMatch FVWM_IS_FVWM3 1, Version < 2.6.8) Schedule 1800 All ("migrate_nscde_1x_2x", CirculateHit) Maximize ewmhiwa
 + I Schedule 2000 All ("migrate_nscde_1x_2x", CirculateHit) Layer 0 6
 + I Break
-

--- a/lib/fvwm-modules/FvwmScript.in
+++ b/lib/fvwm-modules/FvwmScript.in
@@ -1,5 +1,18 @@
 #!@KSH@
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="NsCDE"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Check if there is a XOverrideFontCursor.so for LD_PRELOAD and if LD_PRELOAD is already in
 # use so we can append to the variable, and be careful to use colon as library object separator
 OS_PLUS_MACHINE_ARCH=$(uname -sm | tr ' ' '_')
@@ -22,7 +35,7 @@ if [ -x "$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so" ]; then
             fi
          fi
       else
-         echo "Notice: $NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so is already preloaded; skipping it." >&2
+         printf "$(nscde_gettext 'Notice: %s is already preloaded; skipping it.')\n" "$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so" >&2
       fi
    else
       export LD_PRELOAD="$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so"

--- a/lib/fvwm-modules/FvwmScript.in
+++ b/lib/fvwm-modules/FvwmScript.in
@@ -22,7 +22,7 @@ if [ -x "$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so" ]; then
             fi
          fi
       else
-         echo "Notice: $NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so is already ld-preloaded, skipping" >&2
+         echo "Notice: $NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so is already preloaded; skipping it." >&2
       fi
    else
       export LD_PRELOAD="$NSCDE_LIBDIR/$OS_PLUS_MACHINE_ARCH/XOverrideFontCursor.so"
@@ -31,4 +31,3 @@ fi
 
 # Call the real FvwmScript
 exec ${FVWM_MODULEDIR}/FvwmScript "$@"
-

--- a/lib/python/MiscFun.py.in
+++ b/lib/python/MiscFun.py.in
@@ -13,6 +13,10 @@ import os.path
 import subprocess
 import sys
 import os
+import gettext
+
+_LOCALE_DIR = os.path.normpath(os.path.join("@NSCDE_DATADIR@", os.pardir, "locale"))
+_ = gettext.translation("NsCDE", localedir=_LOCALE_DIR, fallback=True).gettext
 
 def execWithShell1(cmd):
     print (cmd)
@@ -25,30 +29,28 @@ def execWithShell(cmd):
         output=subprocess.check_output(cmd, shell=True)
     except subprocess.CalledProcessError as e:
         print (cmd)
-        print ('ERROR')
+        print (_('ERROR'))
         print (e.output)
         output=''
     return output
 def execWithShellThread(cmd):
-        try: 
-            p=subprocess.Popen(cmd,shell=True) 
-        except OSError as e: 
-            #this doesnt seem to work
+        try:
+            p=subprocess.Popen(cmd,shell=True)
+        except OSError as e:
             print (cmd)
-            print ('ERROR')
-            print (e.output)
+            print (_('ERROR'))
+            print (e)
             p=''
         return p
 def checkFile(filename):
     if os.path.isfile(filename):
         return filename
     else:
-        print ('FILE NOT FOUND: '+filename)
-        sys.exit()
+        print (_('FILE NOT FOUND: %s') % filename)
+        sys.exit(1)
 def checkDir(filename):
     if os.path.isdir(filename):
         return filename
     else:
-        print ('DIRECTORY NOT FOUND: '+filename)
-        sys.exit()
-
+        print (_('DIRECTORY NOT FOUND: %s') % filename)
+        sys.exit(1)

--- a/lib/python/Opts.py.in
+++ b/lib/python/Opts.py.in
@@ -37,7 +37,7 @@ class Opts():
     # load and replace current object namespace with loaded
     # note: this way because yaml.load/save looks nicer when works on dict instead of class
     def load(self,filename):
-        print ('Opts() LOADING '+filename)
+        print ('Loading options from: '+filename)
         with open(filename, 'r') as stream:
             tmpdict = yaml.load(stream)
         # if file is empty(tmpdict=None), do nothing. Then in all classes default values for opts will be used
@@ -48,10 +48,10 @@ class Opts():
     # save namespace (or something)
     def save(self,filename):
         backup=filename+'.backup'
-        print ('Copying old config file to '+backup)
+        print ('Backing up configuration to: '+backup)
         cmd='cp'+' '+filename+' '+backup
         output = subprocess.check_output(cmd, shell=True)
-        print ('Opts() SAVING CONFIG FILE '+filename)
+        print ('Saving configuration to: '+filename)
         with open(filename, 'w') as outfile:
             yaml.dump(self.__dict__, outfile)
 
@@ -90,4 +90,3 @@ def main():
 
 if __name__ == '__main__':
    main()
-

--- a/lib/python/Opts.py.in
+++ b/lib/python/Opts.py.in
@@ -10,6 +10,10 @@
 import os.path
 import yaml
 import subprocess
+import gettext
+
+_LOCALE_DIR = os.path.normpath(os.path.join("@NSCDE_DATADIR@", os.pardir, "locale"))
+_ = gettext.translation("NsCDE", localedir=_LOCALE_DIR, fallback=True).gettext
 
 # loadable opts for various classes. Maybe get rid of functions later
 class Opts():
@@ -37,7 +41,7 @@ class Opts():
     # load and replace current object namespace with loaded
     # note: this way because yaml.load/save looks nicer when works on dict instead of class
     def load(self,filename):
-        print ('Loading options from: '+filename)
+        print (_('Loading options from: %s') % filename)
         with open(filename, 'r') as stream:
             tmpdict = yaml.load(stream)
         # if file is empty(tmpdict=None), do nothing. Then in all classes default values for opts will be used
@@ -48,10 +52,10 @@ class Opts():
     # save namespace (or something)
     def save(self,filename):
         backup=filename+'.backup'
-        print ('Backing up configuration to: '+backup)
+        print (_('Backing up configuration to: %s') % backup)
         cmd='cp'+' '+filename+' '+backup
         output = subprocess.check_output(cmd, shell=True)
-        print ('Saving configuration to: '+filename)
+        print (_('Saving configuration to: %s') % filename)
         with open(filename, 'w') as outfile:
             yaml.dump(self.__dict__, outfile)
 

--- a/lib/python/Theme.py.in
+++ b/lib/python/Theme.py.in
@@ -26,9 +26,9 @@ class Theme():
         # checkDir(userhome)
         homedotthemes=os.path.join(userhome,'.themes')
         if not os.path.exists(homedotthemes):
-            print ('Dot themes dir not found. Creating: '+homedotthemes)
+            print ('Themes directory not found; creating: '+homedotthemes)
             try: os.makedirs(homedotthemes)
-            except OSError as e: sys.stderr.write("Failed to create ~/.themes stop.\n"), e
+            except OSError as e: sys.stderr.write("Failed to create ~/.themes: "+str(e)+"\n")
             sys.exit(2)
 
         # if .themes/NsCDE not exist: copy
@@ -39,8 +39,8 @@ class Theme():
             print (Globals.themesrcdir)
             #sys.exit()
             if not os.path.exists(Globals.themedir):
-                print ('NOT FOUND THEME DIR '+Globals.themedir)
-                print ('Trying to copy from default ')
+                print ('Theme directory not found: '+Globals.themedir)
+                print ('Copying the default theme from: '+Globals.themesrcdir)
                 shutil.copytree(Globals.themesrcdir,Globals.themedir,symlinks=True)
 
             if os.path.lexists(Globals.userthemedir): shutil.rmtree(Globals.userthemedir)
@@ -60,8 +60,8 @@ class Theme():
 
     # Zees eeze nedded unly vunce
     def doUpdateTheme(self):
-        print ("Generate for Gtk2:", self.opts.themeGtk2)
-        print ("Generate for Gtk3:", self.opts.themeGtk3)
+        print ("Generating Gtk2 theme:", self.opts.themeGtk2)
+        print ("Generating Gtk3 theme:", self.opts.themeGtk3)
 
         palettefilefullpath=os.path.join(Globals.palettedir,self.opts.currentpalettefile)
 
@@ -74,4 +74,3 @@ class Theme():
             filename=os.path.join(Globals.userthemedir,'gtk-3.20/cdecolors.css')
             ThemeGtk.gengtk3colors(filename,self.opts)
             ThemeGtk.updateThemeImages(self.opts)
-

--- a/lib/python/Theme.py.in
+++ b/lib/python/Theme.py.in
@@ -15,6 +15,10 @@ from os.path import expanduser
 from MiscFun import *
 import ThemeGtk
 import shutil
+import gettext
+
+_LOCALE_DIR = os.path.normpath(os.path.join("@NSCDE_DATADIR@", os.pardir, "locale"))
+_ = gettext.translation("NsCDE", localedir=_LOCALE_DIR, fallback=True).gettext
 
 class Theme():
     def __init__(self,opts):
@@ -26,10 +30,12 @@ class Theme():
         # checkDir(userhome)
         homedotthemes=os.path.join(userhome,'.themes')
         if not os.path.exists(homedotthemes):
-            print ('Themes directory not found; creating: '+homedotthemes)
-            try: os.makedirs(homedotthemes)
-            except OSError as e: sys.stderr.write("Failed to create ~/.themes: "+str(e)+"\n")
-            sys.exit(2)
+            print (_('Themes directory not found; creating: %s') % homedotthemes)
+            try:
+                os.makedirs(homedotthemes)
+            except OSError as e:
+                sys.stderr.write(_('Failed to create ~/.themes: %s\n') % e)
+                sys.exit(2)
 
         # if .themes/NsCDE not exist: copy
         if os.path.exists(homedotthemes):
@@ -39,8 +45,8 @@ class Theme():
             print (Globals.themesrcdir)
             #sys.exit()
             if not os.path.exists(Globals.themedir):
-                print ('Theme directory not found: '+Globals.themedir)
-                print ('Copying the default theme from: '+Globals.themesrcdir)
+                print (_('Theme directory not found: %s') % Globals.themedir)
+                print (_('Copying the default theme from: %s') % Globals.themesrcdir)
                 shutil.copytree(Globals.themesrcdir,Globals.themedir,symlinks=True)
 
             if os.path.lexists(Globals.userthemedir): shutil.rmtree(Globals.userthemedir)
@@ -60,8 +66,8 @@ class Theme():
 
     # Zees eeze nedded unly vunce
     def doUpdateTheme(self):
-        print ("Generating Gtk2 theme:", self.opts.themeGtk2)
-        print ("Generating Gtk3 theme:", self.opts.themeGtk3)
+        print (_('Generating Gtk2 theme: %s') % self.opts.themeGtk2)
+        print (_('Generating Gtk3 theme: %s') % self.opts.themeGtk3)
 
         palettefilefullpath=os.path.join(Globals.palettedir,self.opts.currentpalettefile)
 

--- a/lib/scripts/ActionForm
+++ b/lib/scripts/ActionForm
@@ -4,7 +4,8 @@
 # Licence: GPLv3
 #
 
-WindowTitle {Question}
+UseGettext {$NSCDE_ROOT/share/locale;NsCDE}
+WindowLocaleTitle {Question}
 WindowSize 400 134
 Colorset 22
 
@@ -24,7 +25,7 @@ Begin
 
         If $TaskText == {} Then
         Begin
-           ChangeTitle 1 {Please select option you want:}
+           ChangeLocaleTitle 1 {Please select option you want:}
         End
         Else
         Begin
@@ -46,7 +47,7 @@ Begin
 
         If $OkStr == {} Then
         Begin
-           ChangeTitle 4 {OK}
+           ChangeLocaleTitle 4 {OK}
         End
         Else
         Begin
@@ -55,7 +56,7 @@ Begin
 
         If $CancelStr == {} Then
         Begin
-           ChangeTitle 5 {Cancel}
+           ChangeLocaleTitle 5 {Cancel}
         End
         Else
         Begin
@@ -123,7 +124,7 @@ Widget 4
    Size 96 0
    Position 16 94
    Type PushButton
-   Title {OK}
+   LocaleTitle {OK}
    Font "xft:::pixelsize=15"
    Flags NoReliefString Center
    Main
@@ -144,7 +145,7 @@ Widget 5
    Size 96 0
    Position 288 94
    Type PushButton
-   Title {Dismiss}
+   LocaleTitle {Dismiss}
    Font "xft:::pixelsize=15"
    Flags NoReliefString Center
    Main
@@ -179,4 +180,3 @@ Widget 6
       Begin
       End
 End
-

--- a/lib/scripts/BackdropMgr.in
+++ b/lib/scripts/BackdropMgr.in
@@ -726,7 +726,7 @@ Widget 12
                   # Workaround FvwmScript lack of programatic cases or elifs ...
                   If $CheckPhotoFileConv <> {noconv} Then
                   Begin
-                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "Error from $[NSCDE_TOOLSDIR]/backdropmgr: } $CheckPhotoFileConv {."}
+                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "Error from backdropmgr: } $CheckPhotoFileConv {."}
                   End
                End
             End
@@ -1006,4 +1006,3 @@ Widget 19
          Do {f_DisplayURL "$[gt.Backdrop Style Manager]" html/NsCDE-BackdropMgr.html}
       End
 End
-

--- a/lib/scripts/BackdropMgr.in
+++ b/lib/scripts/BackdropMgr.in
@@ -147,7 +147,7 @@ Widget 1
    Type ItemDraw
    Flags NoReliefString Left NoFocus
    Colorset 22
-   Title { Backdrops }
+   LocaleTitle { Backdrops }
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -296,7 +296,7 @@ Widget 5
 
          # Set picture name in the upper title
          Set $StrSpace = (Add $StrLen 84)
-         Set $NameInTitle = { Pictures: } $PhotoName
+         Set $NameInTitle = { } (Gettext {Pictures:}) { } $PhotoName
          ChangeSize 1 $StrSpace 22
          ChangeTitle 1 $NameInTitle
       End
@@ -356,7 +356,7 @@ Widget 6
    Font "xft:::pixelsize=15"
    Flags NoReliefString Left
    Value 0
-   Title { Use this backdrop for all workspaces}
+   LocaleTitle { Use this backdrop for all workspaces}
    Colorset 22
    Main
       Case message of
@@ -384,7 +384,7 @@ Widget 7
    Font "xft:::pixelsize=15"
    Flags NoReliefString Left
    Value 0
-   Title { Use a photo or picture}
+   LocaleTitle { Use a photo or picture}
    Colorset 22
    Main
       Case message of
@@ -392,7 +392,7 @@ Widget 7
       Begin
          If (GetValue 7) == 1 Then
          Begin
-            ChangeTitle 1 { Pictures }
+            ChangeLocaleTitle 1 { Pictures }
             ChangeSize 1 80 22
             Set $Photos = (GetOutput {$NSCDE_TOOLSDIR/backdropmgr -P} 1 -1)
             ChangeTitle 5 $Photos
@@ -408,7 +408,7 @@ Widget 7
          End
          Else
          Begin
-            ChangeTitle 1 { Backdrops }
+            ChangeLocaleTitle 1 { Backdrops }
             ChangeSize 1 90 22
             Set $Backdrops = (GetOutput {$NSCDE_TOOLSDIR/backdropmgr -p} 1 -1)
             ChangeTitle 5 $Backdrops
@@ -460,7 +460,7 @@ Widget 9
    Type PopupMenu
    Flags NoReliefString
    Value 0
-   Title { Default for this Workspace| Background Variant 1| Background Variant 2| Background Variant 3| Background Variant 4 }
+   LocaleTitle { Default for this Workspace| Background Variant 1| Background Variant 2| Background Variant 3| Background Variant 4 }
    Font "xft:::pixelsize=15"
    Colorset 22
    Main
@@ -545,11 +545,11 @@ Widget 10
          If $CurrentPalette == {DEFAULT} Then
          Begin
             Set $CurrentPalette = $DefaultPalette
-            ChangeTitle 10 { Load Custom Palette ...}
+            ChangeLocaleTitle 10 { Load Custom Palette ... }
          End
          Else
          Begin
-            Set $NewWidgetTitle = {Palette: } $CurrentPalette
+            Set $NewWidgetTitle = (Gettext {Palette:}) { } $CurrentPalette
             ChangeTitle 10 $NewWidgetTitle
          End
       End
@@ -561,7 +561,7 @@ Widget 11
    Position 340 342
    Type PushButton
    Flags NoReliefString
-   Title { Preview | Preview | Revert }
+   LocaleTitle { Preview | Preview | Revert }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -726,7 +726,7 @@ Widget 12
                   # Workaround FvwmScript lack of programatic cases or elifs ...
                   If $CheckPhotoFileConv <> {noconv} Then
                   Begin
-                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "Error from backdropmgr: } $CheckPhotoFileConv {."}
+                     Do {f_Notifier "Backdrop Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error from backdropmgr:] } $CheckPhotoFileConv {."}
                   End
                End
             End

--- a/lib/scripts/ChoiceForm
+++ b/lib/scripts/ChoiceForm
@@ -4,7 +4,8 @@
 # Licence: GPLv3
 #
 
-WindowTitle {Question}
+UseGettext {$NSCDE_ROOT/share/locale;NsCDE}
+WindowLocaleTitle {Question}
 WindowSize 400 134
 Colorset 22
 
@@ -22,7 +23,7 @@ Begin
 
         If $TaskText == {} Then
         Begin
-           ChangeTitle 1 {Please select option you want:}
+           ChangeLocaleTitle 1 {Please select option you want:}
         End
         Else
         Begin
@@ -44,7 +45,7 @@ Begin
 
         If $OkStr == {} Then
         Begin
-           ChangeTitle 4 {OK}
+           ChangeLocaleTitle 4 {OK}
         End
         Else
         Begin
@@ -53,7 +54,7 @@ Begin
 
         If $CancelStr == {} Then
         Begin
-           ChangeTitle 5 {Cancel}
+           ChangeLocaleTitle 5 {Cancel}
         End
         Else
         Begin
@@ -117,7 +118,7 @@ Widget 4
    Size 96 0
    Position 16 94
    Type PushButton
-   Title {OK}
+   LocaleTitle {OK}
    Font "xft:::pixelsize=15"
    Flags NoReliefString Center
    Main
@@ -138,7 +139,7 @@ Widget 5
    Size 96 0
    Position 288 94
    Type PushButton
-   Title {Dismiss}
+   LocaleTitle {Dismiss}
    Font "xft:::pixelsize=15"
    Flags NoReliefString Center
    Main
@@ -166,4 +167,3 @@ Widget 6
       Begin
       End
 End
-

--- a/lib/scripts/ColorMgr.in
+++ b/lib/scripts/ColorMgr.in
@@ -327,7 +327,7 @@ Widget 1
    Position 16 8
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title { Palettes }
+   LocaleTitle { Palettes }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -445,7 +445,7 @@ Widget 4
    Position 296 44
    Type PushButton
    Flags NoReliefString
-   Title { Preview | Preview | Revert }
+   LocaleTitle { Preview | Preview | Revert }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -610,7 +610,7 @@ Widget 7
    Position 16 205
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title {Palette Name}
+   LocaleTitle {Palette Name}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -1158,7 +1158,7 @@ Widget 21
    Position 12 370
    Type PushButton
    Flags NoReliefString
-   Title { Color Style Integration Options ... }
+   LocaleTitle { Color Style Integration Options ... }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -1974,4 +1974,3 @@ Widget 34
          Do {f_DisplayURL "$[gt.Color Style Manager]" html/NsCDE-ColorMgr.html}
       End
 End
-

--- a/lib/scripts/ExecDialog.in
+++ b/lib/scripts/ExecDialog.in
@@ -181,7 +181,7 @@ Widget 2
    Font "xft:::pixelsize=15"
    Value 0
    Flags NoReliefString
-   Title { Execute in terminal}
+   LocaleTitle { Execute in terminal}
 End
 
 Widget 3
@@ -192,7 +192,7 @@ Widget 3
    Font "xft:::pixelsize=15"
    Value 0
    Flags NoReliefString
-   Title { Leave this dialog open}
+   LocaleTitle { Leave this dialog open}
 End
 
 Widget 4
@@ -268,4 +268,3 @@ Widget 8
    Title {WWWWWWWWWWWWWWWWWWWWWWWWWWW}
    Flags NoReliefString Hidden NoFocus
 End
-

--- a/lib/scripts/FilePicker
+++ b/lib/scripts/FilePicker
@@ -251,7 +251,7 @@ Widget 12
    Position 20 386
    Flags NoReliefString Left
    Type CheckBox
-   Title { Show hidden files        }
+   LocaleTitle { Show hidden files        }
    Font "xft:::pixelsize=15"
    Main
    Case message of
@@ -430,4 +430,3 @@ Widget 14
       Begin
       End
 End
-

--- a/lib/scripts/FontMgr.in
+++ b/lib/scripts/FontMgr.in
@@ -327,7 +327,7 @@ Widget 2
    Type PopupMenu
    Font "xft:::pixelsize=15"
    Value 2
-   Title { Create a New Fontset              | Choose Existing Fontset           }
+   LocaleTitle { Create a New Fontset              | Choose Existing Fontset           }
    Main
       Case message of
       SingleClic :
@@ -1074,7 +1074,7 @@ Widget 15
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
+   LocaleTitle {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1144,7 +1144,7 @@ Widget 16
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
+   LocaleTitle {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1214,7 +1214,7 @@ Widget 17
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
+   LocaleTitle {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1284,7 +1284,7 @@ Widget 18
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
+   LocaleTitle {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1354,7 +1354,7 @@ Widget 19
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
+   LocaleTitle {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1455,7 +1455,7 @@ Widget 22
    Type PushButton
    Font "xft:::pixelsize=14"
    Value 1
-   Title { Font Style Integration Options ...}
+   LocaleTitle { Font Style Integration Options ...}
    Main
       Case message of
       SingleClic :

--- a/lib/scripts/FontMgr.in
+++ b/lib/scripts/FontMgr.in
@@ -1074,7 +1074,7 @@ Widget 15
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1144,7 +1144,7 @@ Widget 16
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1214,7 +1214,7 @@ Widget 17
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1284,7 +1284,7 @@ Widget 18
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -1354,7 +1354,7 @@ Widget 19
    Colorset 22
    Flags NoReliefString Left
    Type ItemDraw
-   Title {Quick Brown Fox}
+   Title {Quick Brown Fox Jumps Over a Lazy Dog ...}
    Font "xft:::pixelsize=24"
    Main
       Case message of
@@ -2236,4 +2236,3 @@ Widget 101
       End
    End
 End
-

--- a/lib/scripts/FpIconMgr
+++ b/lib/scripts/FpIconMgr
@@ -336,7 +336,7 @@ Widget 12
             Set $Perform = (GetOutput $PerformCmd 1 -1)
             If $Perform <> {} Then
             Begin
-               Do {f_Notifier "Front Panel Icon Manager" "Dismiss" "NsCDE/Warning.xpm" "Unexpected output while setting the icon: } $Perform
+               Do {f_Notifier "Front Panel Icon Manager" "Dismiss" "NsCDE/Warning.xpm" "$[gt.Unexpected output while setting the icon:] } $Perform
             End
          End
          Quit
@@ -467,4 +467,3 @@ Widget 15
          End
       End
 End
-

--- a/lib/scripts/GWMOptions
+++ b/lib/scripts/GWMOptions
@@ -416,7 +416,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\" } (Gettext {emerged while appending backdrops value in}) { } $WSMCONF {." "e1"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\" } (Gettext {occurred while appending backdrops value in}) { } $WSMCONF {." "e1"}
                   Quit
                End
             End
@@ -428,7 +428,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\" } (Gettext {emerged while changing backdrops value in}) { } $WSMCONF
+                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\" } (Gettext {occurred while changing backdrops value in}) { } $WSMCONF
                   Quit
                End
             End
@@ -446,7 +446,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\" } (Gettext {emerged while appending highlight value in}) { } $WSMCONF {." "e3"}
+                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\" } (Gettext {occurred while appending highlight value in}) { } $WSMCONF {." "e3"}
                   Quit
                End
             End
@@ -458,7 +458,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\" } (Gettext {emerged while changing highlight value in}) { } $WSMCONF {." "e4"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\" } (Gettext {occurred while changing highlight value in}) { } $WSMCONF {." "e4"}
                   Quit
                End
             End
@@ -476,7 +476,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\" } (Gettext {emerged while appending workspace name label value in}) { } $WSMCONF {." "e5"}
+                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\" } (Gettext {occurred while appending workspace name label value in}) { } $WSMCONF {." "e5"}
                   Quit
                End
             End
@@ -488,7 +488,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\" } (Gettext {emerged while changing workspace name label value in}) { } $WSMCONF {." "e6"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\" } (Gettext {occurred while changing workspace name label value in}) { } $WSMCONF {." "e6"}
                   Quit
                End
             End
@@ -506,7 +506,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\" } (Gettext {emerged while appending GWM rows value in}) { } $WSMCONF {." "e7"}
+                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\" } (Gettext {occurred while appending GWM rows value in}) { } $WSMCONF {." "e7"}
                   Quit
                End
             End
@@ -518,7 +518,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\" } (Gettext {emerged while changing GWM rows value in}) { } $WSMCONF {." "e8"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\" } (Gettext {occurred while changing GWM rows value in}) { } $WSMCONF {." "e8"}
                   Quit
                End
             End
@@ -536,7 +536,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\" } (Gettext {emerged while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\" } (Gettext {occurred while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
                   Quit
                End
             End
@@ -548,7 +548,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\" } (Gettext {emerged while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\" } (Gettext {occurred while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
                   Quit
                End
             End
@@ -566,7 +566,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\" } (Gettext {emerged while adding balloons display value in}) { } $WSMCONF {." "e11"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\" } (Gettext {occurred while adding balloons display value in}) { } $WSMCONF {." "e11"}
                   Quit
                End
             End
@@ -578,7 +578,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\" } (Gettext {emerged while changing balloons display value in}) { } $WSMCONF {." "e12"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\" } (Gettext {occurred while changing balloons display value in}) { } $WSMCONF {." "e12"}
                   Quit
                End
             End
@@ -596,7 +596,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\" } (Gettext {emerged while adding skip list value in}) { } $WSMCONF {." "e13"}
+                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\" } (Gettext {occurred while adding skip list value in}) { } $WSMCONF {." "e13"}
                   Quit
                End
             End
@@ -608,7 +608,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\" } (Gettext {emerged while changing skip list value in}) { } $WSMCONF {." "e14"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\" } (Gettext {occurred while changing skip list value in}) { } $WSMCONF {." "e14"}
                   Quit
                End
             End
@@ -626,7 +626,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\" } (Gettext {emerged while appending window content type value in}) { } $WSMCONF {." "e15"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\" } (Gettext {occurred while appending window content type value in}) { } $WSMCONF {." "e15"}
                   Quit
                End
             End
@@ -638,7 +638,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\" } (Gettext {emerged while changing window content type value in}) { } $WSMCONF {." "e16"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\" } (Gettext {occurred while changing window content type value in}) { } $WSMCONF {." "e16"}
                   Quit
                End
             End
@@ -886,4 +886,3 @@ Widget 20
          Do {f_DisplayURL "$[gt.GWM]" html/NsCDE-GWM.html}
       End
 End
-

--- a/lib/scripts/GWMOptions
+++ b/lib/scripts/GWMOptions
@@ -93,7 +93,7 @@ Widget 1
    Position 18 8
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title {  Workspaces  }
+   LocaleTitle {  Workspaces  }
    Font "xft:::pixelsize=15"
 End
 
@@ -112,7 +112,7 @@ Widget 3
    Type CheckBox
    Flags NoReliefString Left
    Value 0
-   Title { Show Workspace Backdrops          }
+   LocaleTitle { Show Workspace Backdrops          }
    Font "xft:::pixelsize=14"
    Main
       Case message of
@@ -128,7 +128,7 @@ Widget 4
    Type CheckBox
    Flags NoReliefString Left
    Value 0
-   Title { Highlight Current Workspace Page                  }
+   LocaleTitle { Highlight Current Workspace Page                  }
    Font "xft:::pixelsize=14"
    Main
       Case message of
@@ -292,7 +292,7 @@ Widget 11
    Position 18 310
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title { Windows }
+   LocaleTitle { Windows }
    Font "xft:::pixelsize=15"
 End
 
@@ -311,7 +311,7 @@ Widget 13
    Type CheckBox
    Flags NoReliefString Left
    Value 0
-   Title { Show Window Names In Balloons }
+   LocaleTitle { Show Window Names In Balloons }
    Font "xft:::pixelsize=14"
    Main
       Case message of
@@ -327,7 +327,7 @@ Widget 14
    Type CheckBox
    Flags NoReliefString Left
    Value 1
-   Title { Respect Window Skip List            }
+   LocaleTitle { Respect Window Skip List            }
    Font "xft:::pixelsize=14"
    Main
       Case message of
@@ -416,7 +416,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\" } (Gettext {occurred while appending backdrops value in}) { } $WSMCONF {." "e1"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBackdropsValue {\\\"} (Gettext { occurred while appending backdrops value in}) { } $WSMCONF {." "e1"}
                   Quit
                End
             End
@@ -428,7 +428,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\" } (Gettext {occurred while changing backdrops value in}) { } $WSMCONF
+                     {"} (Gettext {Error}) { \\\"} $ChangeBackdropsValue {\\\"} (Gettext { occurred while changing backdrops value in}) { } $WSMCONF
                   Quit
                End
             End
@@ -446,7 +446,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\" } (Gettext {occurred while appending highlight value in}) { } $WSMCONF {." "e3"}
+                     {"} (Gettext {Error}) { \\\"} $AppendHlCurrentValue {\\\"} (Gettext { occurred while appending highlight value in}) { } $WSMCONF {." "e3"}
                   Quit
                End
             End
@@ -458,7 +458,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\" } (Gettext {occurred while changing highlight value in}) { } $WSMCONF {." "e4"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeHlCurrentValue {\\\"} (Gettext { occurred while changing highlight value in}) { } $WSMCONF {." "e4"}
                   Quit
                End
             End
@@ -476,7 +476,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\" } (Gettext {occurred while appending workspace name label value in}) { } $WSMCONF {." "e5"}
+                     {"} (Gettext {Error}) { \\\"} $AppendLabelPosValue {\\\"} (Gettext { occurred while appending workspace name label value in}) { } $WSMCONF {." "e5"}
                   Quit
                End
             End
@@ -488,7 +488,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\" } (Gettext {occurred while changing workspace name label value in}) { } $WSMCONF {." "e6"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeLabelPosValue {\\\"} (Gettext { occurred while changing workspace name label value in}) { } $WSMCONF {." "e6"}
                   Quit
                End
             End
@@ -506,7 +506,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\" } (Gettext {occurred while appending GWM rows value in}) { } $WSMCONF {." "e7"}
+                     {"} (Gettext {Error}) { \\\"} $AppendGwmRowsValue {\\\"} (Gettext { occurred while appending GWM rows value in}) { } $WSMCONF {." "e7"}
                   Quit
                End
             End
@@ -518,7 +518,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\" } (Gettext {occurred while changing GWM rows value in}) { } $WSMCONF {." "e8"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeGwmRowsValue {\\\"} (Gettext { occurred while changing GWM rows value in}) { } $WSMCONF {." "e8"}
                   Quit
                End
             End
@@ -536,7 +536,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\" } (Gettext {occurred while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWscaleValue {\\\"} (Gettext { occurred while adding GWM width scale value in}) { } $WSMCONF {." "e9"}
                   Quit
                End
             End
@@ -548,7 +548,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\" } (Gettext {occurred while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWscaleValue {\\\"} (Gettext { occurred while changing GWM width scale value in}) { } $WSMCONF {." "e10"}
                   Quit
                End
             End
@@ -566,7 +566,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\" } (Gettext {occurred while adding balloons display value in}) { } $WSMCONF {." "e11"}
+                     {"} (Gettext {Error}) { \\\"} $AppendBalloonsValue {\\\"} (Gettext { occurred while adding balloons display value in}) { } $WSMCONF {." "e11"}
                   Quit
                End
             End
@@ -578,7 +578,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\" } (Gettext {occurred while changing balloons display value in}) { } $WSMCONF {." "e12"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeBalloonsValue {\\\"} (Gettext { occurred while changing balloons display value in}) { } $WSMCONF {." "e12"}
                   Quit
                End
             End
@@ -596,7 +596,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\" } (Gettext {occurred while adding skip list value in}) { } $WSMCONF {." "e13"}
+                     {"} (Gettext {Error}) { \\\"} $AppendSkipListValue {\\\"} (Gettext { occurred while adding skip list value in}) { } $WSMCONF {." "e13"}
                   Quit
                End
             End
@@ -608,7 +608,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\" } (Gettext {occurred while changing skip list value in}) { } $WSMCONF {." "e14"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeSkipListValue {\\\"} (Gettext { occurred while changing skip list value in}) { } $WSMCONF {." "e14"}
                   Quit
                End
             End
@@ -626,7 +626,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\" } (Gettext {occurred while appending window content type value in}) { } $WSMCONF {." "e15"}
+                     {"} (Gettext {Error}) { \\\"} $AppendWinContentValue {\\\"} (Gettext { occurred while appending window content type value in}) { } $WSMCONF {." "e15"}
                   Quit
                End
             End
@@ -638,7 +638,7 @@ Widget 18
                Begin
                   Do {None ("} (Gettext {Graphical Workspace Manager Error}) {")}
                      { f_Notifier "} (Gettext {Graphical Workspace Manager Error}) {" "Dismiss" "NsCDE/Error.xpm" }
-                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\" } (Gettext {occurred while changing window content type value in}) { } $WSMCONF {." "e16"}
+                     {"} (Gettext {Error}) { \\\"} $ChangeWinContentValue {\\\"} (Gettext { occurred while changing window content type value in}) { } $WSMCONF {." "e16"}
                   Quit
                End
             End

--- a/lib/scripts/GeometryMgr
+++ b/lib/scripts/GeometryMgr
@@ -112,7 +112,7 @@ Widget 1
    Position 18 4
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title {      Set Window Initial Geometry      }
+   LocaleTitle { Set Window Initial Geometry }
    Font "xft:::pixelsize=15"
 End
 
@@ -526,4 +526,3 @@ Widget 30
       End
 
 End
-

--- a/lib/scripts/InputForm
+++ b/lib/scripts/InputForm
@@ -14,7 +14,7 @@ Begin
    Set $TaskText = (GetScriptArgument 1)
    If $TaskText == {} Then
    Begin
-      ChangeTitle 1 {Enter Required Parameter:}
+      ChangeLocaleTitle 1 {Enter Required Parameter:}
    End
    Else
    Begin
@@ -82,7 +82,7 @@ Widget 1
    Position 72 6
    Type ItemDraw
    Flags NoReliefString NoFocus Left
-   Title {Enter Required Parameter: }
+   LocaleTitle {Enter Required Parameter:}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -225,4 +225,3 @@ Widget 10
          End
       End
 End
-

--- a/lib/scripts/KeyboardMgr.in
+++ b/lib/scripts/KeyboardMgr.in
@@ -119,7 +119,7 @@ Widget 3
    Position 10 58
    Flags NoReliefString
    Type CheckBox
-   Title { Auto Repeat                                }
+   LocaleTitle { Auto Repeat                                }
    Font "xft:::pixelsize=14"
    Main
       Case message of
@@ -419,4 +419,3 @@ Widget 16
          Quit
       End
 End
-

--- a/lib/scripts/ModifyColor
+++ b/lib/scripts/ModifyColor
@@ -174,7 +174,7 @@ Widget 5
          End
          Else
          Begin
-            Do {f_Notifier "Color Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error occured while calling Color Selector:] \\\"} $GrabHEX {\\\"}
+            Do {f_Notifier "Color Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error occurred while calling Color Selector:] \\\"} $GrabHEX {\\\"}
          End
       End
 End
@@ -529,4 +529,3 @@ Widget 23
          Do {f_DisplayURL "$[gt.Color Style Manager]" html/NsCDE-ColorMgr.html}
       End
 End
-

--- a/lib/scripts/NColorsDialog
+++ b/lib/scripts/NColorsDialog
@@ -172,7 +172,7 @@ Widget 6
    Font "xft:::pixelsize=15"
    Flags NoReliefString Left
    Value 0
-   Title { Color 8 for Front Panel and Icons}
+   LocaleTitle { Color 8 for Front Panel and Icons}
    Main
       Case message of
       SingleClic :
@@ -203,7 +203,7 @@ Widget 7
    Font "xft:::pixelsize=15"
    Flags NoReliefString Left
    Value 0
-   Title { Color 6 for Workspace Manager}
+   LocaleTitle { Color 6 for Workspace Manager}
    Main
       Case message of
       SingleClic :
@@ -300,4 +300,3 @@ Property
          Do {f_DisplayURL "$[gt.Color Style Manager]" html/NsCDE-ColorMgr.html}
       End
 End
-

--- a/lib/scripts/NProcMgr
+++ b/lib/scripts/NProcMgr
@@ -5,7 +5,7 @@
 #
 
 UseGettext {$NSCDE_ROOT/share/locale;NsCDE-NProcMgr}
-WindowLocaleTitle { NsCDE Proces Management }
+WindowLocaleTitle { NsCDE Process Management }
 WindowSize 502 732
 Colorset 22
 
@@ -489,7 +489,7 @@ Property
    Position 20 272
    Type CheckBox
    Flags NoReliefString
-   Title {FvwmAnimate}
+   Title {Fvwm Animate}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -852,7 +852,7 @@ Widget 40
    Position 210 81
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -867,7 +867,7 @@ Widget 41
    Position 210 121
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -882,7 +882,7 @@ Widget 42
    Position 210 157
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -897,7 +897,7 @@ Widget 43
    Position 210 195
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -912,7 +912,7 @@ Widget 44
    Position 210 233
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -927,7 +927,7 @@ Widget 45
    Position 210 271
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -942,7 +942,7 @@ Widget 46
    Position 210 309
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -957,7 +957,7 @@ Widget 47
    Position 210 347
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -972,7 +972,7 @@ Widget 48
    Position 210 385
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -987,7 +987,7 @@ Widget 49
    Position 210 423
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1002,7 +1002,7 @@ Widget 60
    Position 210 461
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1017,7 +1017,7 @@ Widget 61
    Position 210 500
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Enabled, Running (PID: XXXXXXX)}
+   Title {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1337,4 +1337,3 @@ Property
          Do {f_DisplayURL "$[gt.NsCDE Process Manager]" html/NsCDE-NProcMgr.html}
       End
 End
-

--- a/lib/scripts/NProcMgr
+++ b/lib/scripts/NProcMgr
@@ -212,7 +212,7 @@ Widget 2
    Position 18 48
    Type ItemDraw
    Flags NoReliefString NoFocus
-   Title {Processes}
+   LocaleTitle {Processes}
    Main
       Case message of
       SingleClic :
@@ -237,7 +237,7 @@ Property
    Position 20 82
    Type CheckBox
    Flags NoReliefString Left
-   Title {   Fvwm Main Process   }
+   LocaleTitle {  Fvwm Main Process}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -286,7 +286,7 @@ Property
    Position 20 120
    Type CheckBox
    Flags NoReliefString
-   Title {Xsettingsd}
+   LocaleTitle {  Xsettingsd}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -337,7 +337,7 @@ Property
    Position 20 158
    Type CheckBox
    Flags NoReliefString
-   Title {Stalonetray}
+   LocaleTitle {  Stalonetray}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -388,7 +388,7 @@ Property
    Position 20 196
    Type CheckBox
    Flags NoReliefString
-   Title {Xscreensaver}
+   LocaleTitle {  Xscreensaver}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -439,7 +439,7 @@ Property
    Position 20 234
    Type CheckBox
    Flags NoReliefString
-   Title {Fvwm Event}
+   LocaleTitle {  Fvwm Event}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -489,7 +489,7 @@ Property
    Position 20 272
    Type CheckBox
    Flags NoReliefString
-   Title {Fvwm Animate}
+   LocaleTitle {  Fvwm Animate}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -539,7 +539,7 @@ Property
    Position 20 310
    Type CheckBox
    Flags NoReliefString
-   Title {      Front Panel      }
+   LocaleTitle {  Front Panel}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -589,7 +589,7 @@ Property
    Position 20 348
    Type CheckBox
    Flags NoReliefString
-   Title {Local Pager}
+   LocaleTitle {  Local Pager}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -639,7 +639,7 @@ Property
    Position 20 386
    Type CheckBox
    Flags NoReliefString
-   Title {Fvwm Backer}
+   LocaleTitle {  Fvwm Backer}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -696,7 +696,7 @@ Property
    Position 20 424
    Type CheckBox
    Flags NoReliefString
-   Title {      Icon Manager      }
+   LocaleTitle {  Icon Manager}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -749,7 +749,7 @@ Property
    Position 20 462
    Type CheckBox
    Flags NoReliefString
-   Title {   Dunst Notifier   }
+   LocaleTitle {  Dunst Notifier}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -800,7 +800,7 @@ Property
    Position 20 500
    Type CheckBox
    Flags NoReliefString
-   Title {Picom X Compositor}
+   LocaleTitle {  Picom X Compositor}
    Font "xft:::pixelsize=16"
    Value 0
    Main
@@ -852,7 +852,7 @@ Widget 40
    Position 210 81
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -867,7 +867,7 @@ Widget 41
    Position 210 121
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -882,7 +882,7 @@ Widget 42
    Position 210 157
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -897,7 +897,7 @@ Widget 43
    Position 210 195
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -912,7 +912,7 @@ Widget 44
    Position 210 233
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -927,7 +927,7 @@ Widget 45
    Position 210 271
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -942,7 +942,7 @@ Widget 46
    Position 210 309
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -957,7 +957,7 @@ Widget 47
    Position 210 347
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -972,7 +972,7 @@ Widget 48
    Position 210 385
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -987,7 +987,7 @@ Widget 49
    Position 210 423
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1002,7 +1002,7 @@ Widget 60
    Position 210 461
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of
@@ -1017,7 +1017,7 @@ Widget 61
    Position 210 500
    Type ItemDraw
    Flags NoReliefString Right NoFocus
-   Title {Checking ...}
+   LocaleTitle {Checking ...}
    Font "xft:::pixelsize=16"
    Main
       Case message of

--- a/lib/scripts/Occupy
+++ b/lib/scripts/Occupy
@@ -833,7 +833,7 @@ Widget 7
    Type CheckBox
    Value 0
    Flags NoReliefString
-   Title { All Workspaces    }
+   LocaleTitle { All Workspaces    }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -960,7 +960,7 @@ Widget 8
    Type CheckBox
    Value 0
    Flags NoReliefString
-   Title { Go with the Window}
+   LocaleTitle { Go with the Window}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -1153,4 +1153,3 @@ Widget 12
          Do {f_DisplayURL "$[gt.Occupy Workspace]" html/NsCDE-Occupy.html}
       End
 End
-

--- a/lib/scripts/PaletteDialog
+++ b/lib/scripts/PaletteDialog
@@ -53,7 +53,7 @@ Property
    Position 164 20
    Type RadioButton
    Flags NoReliefString
-   Title {   Default     }
+   LocaleTitle { Default }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -155,4 +155,3 @@ Property
          Do {f_DisplayURL "$[gt.Backdrop Style Manager]" html/NsCDE-BackdropMgr.html}
       End
 End
-

--- a/lib/scripts/PointerMgr.in
+++ b/lib/scripts/PointerMgr.in
@@ -183,7 +183,7 @@ Widget 4
    Position 144 112
    Type ItemDraw
    Flags NoReliefString Left NoFocus Hidden
-   Title {First: }
+   LocaleTitle {First: }
 End
 
 Widget 5
@@ -192,7 +192,7 @@ Widget 5
    Position 290 112
    Type ItemDraw
    Flags NoReliefString Left NoFocus Hidden
-   Title {Second: }
+   LocaleTitle {Second: }
 End
 
 Widget 6
@@ -551,4 +551,3 @@ Widget 20
          Quit
       End
 End
-

--- a/lib/scripts/PowerSaveMgr.in
+++ b/lib/scripts/PowerSaveMgr.in
@@ -377,7 +377,7 @@ Widget 6
    Position 18 62
    Flags NoReliefString
    Type CheckBox
-   Title { DPMS Enabled/Disabled                }
+   LocaleTitle { DPMS Enabled/Disabled                }
    Font "xft:::pixelsize=15"
    Value 1
    Main
@@ -430,7 +430,7 @@ Widget 8
    Size 280 0
    Flags NoReliefString NoFocus Left
    Type ItemDraw
-   Title {Off time after (seconds):}
+   LocaleTitle {Off time after (seconds):}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -464,7 +464,7 @@ Widget 10
    Size 280 0
    Flags NoReliefString NoFocus Left
    Type ItemDraw
-   Title {Suspend time after (seconds):}
+   LocaleTitle {Suspend time after (seconds):}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -549,4 +549,3 @@ Widget 14
          ChangeColorset 2 20
       End
 End
-

--- a/lib/scripts/StyleMgr
+++ b/lib/scripts/StyleMgr
@@ -775,7 +775,7 @@ Widget 17
 
             If $CheckDeskRc == {NotListed} Then
             Begin
-               Do {None (NsCDE-Notifier.NotSupp) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "Session Manager from desktop } $CheckDesk { not (yet) supported." "NotSupp"}
+               Do {None (NsCDE-Notifier.NotSupp) f_Notifier "Style Manager" "Dismiss" "NsCDE/Error.xpm" "$[gt.Session Manager from desktop ]} $CheckDesk {$[gt. not (yet) supported.]" "NotSupp"}
             End
          End
          Else
@@ -801,4 +801,3 @@ Widget 37
          Do {SendToModule StyleMgr SendString 6 1 pressed_17_37}
       End
 End
-

--- a/lib/scripts/SubpanelMgr
+++ b/lib/scripts/SubpanelMgr
@@ -682,7 +682,7 @@ Widget 15
    Position 450 346
    Type ItemDraw
    Flags NoReliefString Left Hidden
-   Title {Check for this cmd:}
+   LocaleTitle {Check for this cmd:}
    Font "xft:::pixelsize=15"
    Colorset 22
    Main
@@ -733,7 +733,7 @@ Widget 18
    Flags NoReliefString Left
    Value 0
    Colorset 22
-   Title { Do not check whether the command exists}
+   LocaleTitle { Do not check whether the command exists}
    Font "xft:::pixelsize=15"
    Main
       Case message of

--- a/lib/scripts/SubpanelMgr
+++ b/lib/scripts/SubpanelMgr
@@ -733,7 +733,7 @@ Widget 18
    Flags NoReliefString Left
    Value 0
    Colorset 22
-   Title { Do not check for command existance}
+   Title { Do not check whether the command exists}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -899,4 +899,3 @@ Widget 25
          End
       End
 End
-

--- a/lib/scripts/SubpanelSettings.in
+++ b/lib/scripts/SubpanelSettings.in
@@ -5,7 +5,7 @@
 #
 
 UseGettext {$NSCDE_ROOT/share/locale;NsCDE-Subpanel:$NSCDE_ROOT/share/locale;NsCDE-Subpanels}
-WindowTitle {Subpanel Settings}
+WindowLocaleTitle {Subpanel Settings}
 WindowSize 370 270
 Colorset 22
 
@@ -131,7 +131,7 @@ Widget 1
    Size 320 20
    Type ItemDraw
    Flags NoReliefString Left NoFocus
-   Title {Subpanel Settings: }
+   LocaleTitle {Subpanel Settings: }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -410,12 +410,12 @@ Widget 14
 
          If $GenerateFvwmButtonsCfg2 <> {} Then
          Begin
-            Do {f_Notifier "Subpanel Settings" "Dismiss" "NsCDE/Error.xpm" "Unexpected output from generate_subpanels command: \\\"} $GenerateFvwmButtonsCfg2 {\\\""}
+            Do {f_Notifier "Subpanel Settings" "Dismiss" "NsCDE/Error.xpm" "$[gt.Unexpected output from generate_subpanels command: ]\\\"} $GenerateFvwmButtonsCfg2 {\\\""}
          End
 
          If $GenerateFvwmButtonsCfg3 <> {} Then
          Begin
-            Do {f_Notifier "Subpanel Settings" "Dismiss" "NsCDE/Error.xpm" "Unexpected output from generate_subpanels command: \\\"} $GenerateFvwmButtonsCfg3 {\\\""}
+            Do {f_Notifier "Subpanel Settings" "Dismiss" "NsCDE/Error.xpm" "$[gt.Unexpected output from generate_subpanels command: ]\\\"} $GenerateFvwmButtonsCfg3 {\\\""}
          End
 
          # Case where disabled subpanel has been enabled
@@ -513,4 +513,3 @@ Widget 17
          End
       End
 End
-

--- a/lib/scripts/SysActionDialog
+++ b/lib/scripts/SysActionDialog
@@ -240,7 +240,7 @@ Widget 5
    Type CheckBox
    Font "xft:::pixelsize=14"
    Value 1
-   Title { Remember Last Action                  }
+   LocaleTitle { Remember Last Action                  }
    Main
       Case message of
       SingleClic :
@@ -474,4 +474,3 @@ Property
       Do {f_DisplayURL "$[gt.System Action Dialog]" html/basics_logging_out.html}
    End
 End
-

--- a/lib/scripts/WaitNotice
+++ b/lib/scripts/WaitNotice
@@ -4,7 +4,8 @@
 # Licence: GPLv3
 #
 
-WindowTitle {WaitNotice}
+UseGettext {$NSCDE_ROOT/share/locale;NsCDE}
+WindowLocaleTitle {WaitNotice}
 WindowSize 402 146
 WindowPosition 500 500
 Colorset 22
@@ -77,7 +78,7 @@ Widget 2
    Position 20 62
    Type ItemDraw
    Flags NoReliefString
-   Title { Action in Progress ... }
+   LocaleTitle { Action in Progress ... }
    Main
       Case message of
       SingleClic :
@@ -114,4 +115,3 @@ Widget 4
    Position 6 6
    Type Rectangle
 End
-

--- a/lib/scripts/WindowMgr
+++ b/lib/scripts/WindowMgr
@@ -576,7 +576,7 @@ Widget 4
    Flags NoReliefString
    Value 1
    Font "xft:::pixelsize=15"
-   Title { Window Behavior| Window Icons| Page Edges| Animation}
+   LocaleTitle { Window Behavior| Window Icons| Page Edges| Animation}
    Main
       Case message of
       SingleClic :
@@ -832,7 +832,7 @@ Widget 5
    Position 18 112
    Type ItemDraw
    Flags NoReliefString NoFocus
-   Title { Window Behavior }
+   LocaleTitle {Window Behavior}
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -931,7 +931,7 @@ End
 
 Widget 11
    Property
-   Title { Raise Window When Made Active        }
+   LocaleTitle { Raise Window When Made Active        }
    Position 20 274
    Flags NoReliefString
    Type CheckBox
@@ -959,7 +959,7 @@ End
 
 Widget 12
    Property
-   Title { Allow Primary Windows On Top            }
+   LocaleTitle { Allow Primary Windows On Top            }
    Position 20 314
    Flags NoReliefString
    Type CheckBox
@@ -976,7 +976,7 @@ End
 
 Widget 13
    Property
-   Title { Lower Transient With Primary Window}
+   LocaleTitle { Lower Transient With Primary Window}
    Position 20 354
    Flags NoReliefString
    Type CheckBox
@@ -993,7 +993,7 @@ End
 
 Widget 14
    Property
-   Title { Raise/Lower Primaries With Transients}
+   LocaleTitle { Raise/Lower Primaries With Transients}
    Position 20 394
    Flags NoReliefString
    Type CheckBox
@@ -1010,7 +1010,7 @@ End
 
 Widget 15
    Property
-   Title { Show Contents During Move              }
+   LocaleTitle { Show Contents During Move              }
    Position 20 436
    Flags NoReliefString
    Type CheckBox
@@ -1358,7 +1358,7 @@ End
 
 Widget 31
    Property
-   Title { Raise Front Panel On Page Change}
+   LocaleTitle { Raise Front Panel On Page Change}
    Position 20 156
    Flags NoReliefString
    Type CheckBox
@@ -1375,7 +1375,7 @@ End
 
 Widget 32
    Property
-   Title { Pager Preview On Page Change}
+   LocaleTitle { Pager Preview On Page Change}
    Position 20 206
    Flags NoReliefString
    Type CheckBox
@@ -1556,7 +1556,7 @@ End
 
 Widget 42
    Property
-   Title { Animate Window Iconification}
+   LocaleTitle { Animate Window Iconification}
    Font "xft:::pixelsize=15"
    Position 20 156
    Flags NoReliefString
@@ -1627,7 +1627,7 @@ End
 
 Widget 44
    Property
-   Title {   Frame |   Lines |   Flip |   Turn |   Zoom3D |   Twist |   Random }
+   LocaleTitle {   Frame |   Lines |   Flip |   Turn |   Zoom3D |   Twist |   Random }
    Font "xft:::pixelsize=15"
    Position 200 232
    Flags NoReliefString
@@ -2493,4 +2493,3 @@ Widget 124
          Do {f_DisplayURL "$[gt.Window Style Manager]" html/NsCDE-WindowMgr.html}
       End
 End
-

--- a/lib/scripts/WsPgMgr
+++ b/lib/scripts/WsPgMgr
@@ -234,7 +234,7 @@ Widget 26
    Type CheckBox
    Font "xft:::pixelsize=12"
    Value 1
-   Title { Use Compact Workspace Manager                   }
+   LocaleTitle { Use Compact Workspace Manager                   }
    Main
       Case message of
       SingleClic :
@@ -275,7 +275,7 @@ Property
     Position 50 53
     Size 124 26
     Type PushButton
-    Title { One }
+    LocaleTitle { One }
     Flags Left
     Colorset 40
     Main
@@ -303,7 +303,7 @@ Property
     Position 178 53
     Size 124 26
     Type PushButton
-    Title { Two }
+    LocaleTitle { Two }
     Flags Left
     Colorset 42
     Main
@@ -338,7 +338,7 @@ Property
     Position 50 85
     Size 124 26
     Type PushButton
-    Title { Three }
+    LocaleTitle { Three }
     Flags Left
     Colorset 44
     Main
@@ -371,7 +371,7 @@ Property
     Position 178 85
     Size 124 26
     Type PushButton
-    Title { Four }
+    LocaleTitle { Four }
     Flags Left
     Colorset 46
     Main
@@ -404,7 +404,7 @@ Property
     Position 1 85
     Size 60 26
     Type PushButton
-    Title { Five }
+    LocaleTitle { Five }
     Flags Left
     Colorset 40
     Main
@@ -435,7 +435,7 @@ Property
     Position 65 85
     Size 60 26
     Type PushButton
-    Title { Six }
+    LocaleTitle { Six }
     Flags Left
     Colorset 42
     Main
@@ -466,7 +466,7 @@ Property
     Position 130 85
     Size 60 26
     Type PushButton
-    Title {Seven}
+    LocaleTitle {Seven}
     Flags Left
     Colorset 44
     Main
@@ -494,7 +494,7 @@ Property
     Position 194 85
     Size 60 26
     Type PushButton
-    Title {Eight}
+    LocaleTitle {Eight}
     Flags Left
     Colorset 46
     Main
@@ -779,7 +779,7 @@ Widget 16
    Size 320 20
    Flags NoReliefString NoFocus Left
    Type ItemDraw
-   Title {Nr. of Desks: }
+   LocaleTitle {Nr. of Desks: }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -794,7 +794,7 @@ Widget 17
    Size 320 20
    Flags NoReliefString NoFocus Left
    Type ItemDraw
-   Title {Pages per Desk: }
+   LocaleTitle {Pages per Desk: }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -809,7 +809,7 @@ Widget 18
    Size 320 20
    Flags NoReliefString NoFocus Left
    Type ItemDraw
-   Title {Total Pages: }
+   LocaleTitle {Total Pages: }
    Font "xft:::pixelsize=15"
    Main
       Case message of
@@ -852,7 +852,7 @@ Widget 28
    Flags NoReliefString Left
    Type PopupMenu
    Value 0
-   Title { Global | Per Monitor| Shared }
+   LocaleTitle { Global | Per Monitor| Shared }
    Main
       Case message of
       SingleClic :
@@ -944,7 +944,7 @@ Widget 21
  
          If $DStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck {$[gt. occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -968,7 +968,7 @@ Widget 21
  
          If $PVStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck {$[gt. occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -991,7 +991,7 @@ Widget 21
          End
          If $PHStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck {$[gt. occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -1014,7 +1014,7 @@ Widget 21
          End
          If $WSMECOStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck {$[gt. occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $WSMECOStringToCheck == 1 Then
@@ -1050,7 +1050,7 @@ Widget 21
          End
          If $DskConfStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck {$[gt. occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $DskConfStringToCheck == 1 Then
@@ -1291,7 +1291,7 @@ Widget 24
          Do {SendToModule $[infostore.WSM] SendString 41 5 CHN } $CalledBy { } $NewButtonLabel
          HideWidget 24
          Set $Txt = 0
-         ChangeTitle 22 {Close}
+         ChangeLocaleTitle 22 {Close}
       End
       2 :
       Begin

--- a/lib/scripts/WsPgMgr
+++ b/lib/scripts/WsPgMgr
@@ -20,7 +20,7 @@ Begin
    If $DeskNo == {} Then
    Begin
       Do {None ("Workspaces and Pages Style Manager Warning")}
-          { f_Notifier "Workspaces and Pages Syle Manager Warning" "Dismiss" "NsCDE/Warning.xpm"}
+          { f_Notifier "Workspaces and Pages Style Manager Warning" "Dismiss" "NsCDE/Warning.xpm"}
           { "Warning: Number of Workspaces and/or number of Pages are not set. Using 4 as default."}
 
       Set $DeskNo = 4
@@ -944,7 +944,7 @@ Widget 21
  
          If $DStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -968,7 +968,7 @@ Widget 21
  
          If $PVStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PVStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -991,7 +991,7 @@ Widget 21
          End
          If $PHStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $PHStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
  
@@ -1014,7 +1014,7 @@ Widget 21
          End
          If $WSMECOStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $WSMECOStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $WSMECOStringToCheck == 1 Then
@@ -1050,7 +1050,7 @@ Widget 21
          End
          If $DskConfStringToCheck == 2 Then
          Begin
-            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck { $[gt.occured while checking config file] } $ExpandFile {."}
+            Do {f_Notifier "Config Set Error" "Dismiss" "NsCDE/Error.xpm" "$[gt.Error] } $DskConfStringToCheck { $[gt.occurred while checking config file] } $ExpandFile {."}
             Quit
          End
          If $DskConfStringToCheck == 1 Then
@@ -1328,4 +1328,3 @@ Widget 25
          ChangeColorset 24 20
       End
 End
-

--- a/nscde_tools/FvwmScripts/GWM.in
+++ b/nscde_tools/FvwmScripts/GWM.in
@@ -13,9 +13,22 @@ write_gwm_conf=0
 write_gwm_script=0
 prepare_piperead=0
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 function usage
 {
-   echo "Usage: ${0##*/} -w <viewport width> -h <viewport height> -f <reduction factor> -d <number of desks> [ -c <pager configuration file> ] [ -s ] | [ -H ]"
+   printf "$(nscde_gettext 'Usage: %s -w <viewport width> -h <viewport height> -f <reduction factor> -d <number of desks> [ -c <pager configuration file> ] [ -s ] | [ -H ]')\n" "${0##*/}"
    exit $1
 }
 

--- a/nscde_tools/FvwmScripts/GWM.in
+++ b/nscde_tools/FvwmScripts/GWM.in
@@ -15,7 +15,7 @@ prepare_piperead=0
 
 function usage
 {
-   echo "Usage: ${0##*/} -w <vp width> -h <vp height> -f <reduction factor> -d <no of desks> [ -c <pager conf file> ] [ -s ] | [ -H ]"
+   echo "Usage: ${0##*/} -w <viewport width> -h <viewport height> -f <reduction factor> -d <number of desks> [ -c <pager configuration file> ] [ -s ] | [ -H ]"
    exit $1
 }
 
@@ -770,4 +770,3 @@ fi
 if (($write_gwm_script == 1)); then
    WriteGwmScript
 fi
-

--- a/nscde_tools/FvwmScripts/Notifier.in
+++ b/nscde_tools/FvwmScripts/Notifier.in
@@ -11,7 +11,7 @@ IFS=" "
 
 function usage
 {
-   echo "Usage: ${0##*/} -t <title> -b <buttontitle> -i <icon> [ -s <textstr> | -f <file> ] [ -l <catalog name> ] [ -h ]"
+   echo "Usage: ${0##*/} -t <title> -b <button title> -i <icon> [ -s <text> | -f <file> ] [ -l <catalog name> ] [ -h ]"
    exit $1
 }
 
@@ -251,4 +251,3 @@ Widget 3
 End
 
 EOF
-

--- a/nscde_tools/FvwmScripts/Notifier.in
+++ b/nscde_tools/FvwmScripts/Notifier.in
@@ -9,9 +9,22 @@
 OLD_LC_ALL="$LC_ALL"
 IFS=" "
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 function usage
 {
-   echo "Usage: ${0##*/} -t <title> -b <button title> -i <icon> [ -s <text> | -f <file> ] [ -l <catalog name> ] [ -h ]"
+   printf "$(nscde_gettext 'Usage: %s -t <title> -b <button title> -i <icon> [ -s <text> | -f <file> ] [ -l <catalog name> ] [ -h ]')\n" "${0##*/}"
    exit $1
 }
 
@@ -57,14 +70,14 @@ while getopts t:b:i:s:f:l:h Option
 do
    case $Option in
       t)
-         if $(whence -q gettext); then
+         if whence -q gettext; then
             sh_WindowTitle=$(TEXTDOMAINDIR="$NSCDE_ROOT/share/locale" gettext -d NsCDE -s "$OPTARG")
          else
             sh_WindowTitle="$OPTARG"
          fi
       ;;
       b)
-         if $(whence -q gettext); then
+         if whence -q gettext; then
             sh_ButtonTitle=$(TEXTDOMAINDIR="$NSCDE_ROOT/share/locale" gettext -d NsCDE -s "$OPTARG")
          else
             sh_ButtonTitle="$OPTARG"
@@ -74,7 +87,7 @@ do
          sh_IconFile="$OPTARG"
       ;;
       s)
-         if $(whence -q gettext); then
+         if whence -q gettext; then
             sh_TextString=$(TEXTDOMAINDIR="$NSCDE_ROOT/share/locale" gettext -d NsCDE -s "$OPTARG")
          else
             sh_TextString="$OPTARG"

--- a/nscde_tools/FvwmScripts/Splash.in
+++ b/nscde_tools/FvwmScripts/Splash.in
@@ -51,6 +51,7 @@ else
 fi
 
 cat <<EOF
+UseGettext {$NSCDE_ROOT/share/locale;NsCDE}
 WindowTitle {NsCDE-Splash}
 WindowSize $Width $Height
 WindowPosition 0 0
@@ -111,9 +112,10 @@ Begin
       Set \$FvwmName = {FVWM}
    End
 
-   Set \$VarTitle1 = { Not so Common Desktop Environment } \$Version { running on } \$OS {.}
-   Set \$VarTitle2 = { Using } \$FvwmName { version } \$FvwmVersion { as the Window Manager.}
-   Set \$VarTitle3 = { Starting Up ...}
+   Set \$VarTitle1 = { Not so Common Desktop Environment } \$Version { } (Gettext {running on}) { } \$OS {.}
+   Set \$VarTitle2 = { } (Gettext {Using}) { } \$FvwmName { } (Gettext {version}) { } \$FvwmVersion { } (Gettext {as the Window Manager.})
+   Set \$VarTitle3 = { } (Gettext {Starting Up ...})
+   Set \$LicenceTitle = { } (Gettext {NsCDE is Free Software released under the GPLv3 licence.})
 
    Set \$Beam = {}
    Set \$Beam1 = {I}
@@ -123,10 +125,10 @@ Begin
    Set \$Stop = 0
    Set \$Sec = 0
 
-   ChangeLocaleTitle 5 \$VarTitle1
-   ChangeLocaleTitle 6 \$VarTitle2
-   ChangeLocaleTitle 7 { NsCDE is Free Software released under the GPLv3 licence.}
-   ChangeLocaleTitle 8 \$VarTitle3
+   ChangeTitle 5 \$VarTitle1
+   ChangeTitle 6 \$VarTitle2
+   ChangeTitle 7 \$LicenceTitle
+   ChangeTitle 8 \$VarTitle3
 End
 
 PeriodicTasks
@@ -138,7 +140,7 @@ Begin
       Quit
    End
    SendSignal 8 1
-   ChangeLocaleTitle 8 \$StartupTitle
+   ChangeTitle 8 \$StartupTitle
    Set \$Stop = 0
 End
 
@@ -203,7 +205,7 @@ Widget 5
    Type ItemDraw
    Flags NoReliefString Left
    Colorset 52
-   LocaleTitle {Not so Common Desktop Environment VERSION running on OS.}
+   Title {}
    Main
       Case message of
       SingleClic :
@@ -225,7 +227,7 @@ Widget 6
    Type ItemDraw
    Flags NoReliefString Left
    Colorset 52
-   LocaleTitle {Using FVWM version VERSION as the Window Manager.}
+   Title {}
    Main
       Case message of
       SingleClic :
@@ -324,3 +326,4 @@ Widget 9
       Begin
       End
 End
+EOF

--- a/nscde_tools/FvwmScripts/Splash.in
+++ b/nscde_tools/FvwmScripts/Splash.in
@@ -125,7 +125,7 @@ Begin
 
    ChangeLocaleTitle 5 \$VarTitle1
    ChangeLocaleTitle 6 \$VarTitle2
-   ChangeLocaleTitle 7 { NsCDE is a Free Software released under GPLv3 licence.}
+   ChangeLocaleTitle 7 { NsCDE is Free Software released under the GPLv3 licence.}
    ChangeLocaleTitle 8 \$VarTitle3
 End
 
@@ -240,7 +240,7 @@ Widget 7
    Type ItemDraw
    Flags NoReliefString Left
    Colorset 52
-   LocaleTitle {NsCDE is a Free Software released under GPLv3 licence.}
+   LocaleTitle {NsCDE is Free Software released under the GPLv3 licence.}
    Main
       Case message of
       SingleClic :
@@ -324,4 +324,3 @@ Widget 9
       Begin
       End
 End
-

--- a/nscde_tools/acpimgr.in
+++ b/nscde_tools/acpimgr.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 PATH="/sbin:/usr/sbin:/usr/local/sbin:/bin:/usr/bin:/usr/local/bin:$PATH"
 Action=$1
 
@@ -53,7 +66,7 @@ elif [ "$OS" == "OpenBSD" ]; then
 else
    Opmode=$2
    if [ "x$Opmode" == "x" ]; then
-      echo "Error: unknown ACPI operation mode."
+      printf '%s\n' "$(nscde_gettext 'Error: unknown ACPI operation mode.')"
       exit 4
    fi
 fi
@@ -86,7 +99,7 @@ function hibernate
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: hibernation to disk is not supported on NetBSD."
+      printf '%s\n' "$(nscde_gettext 'Notice: hibernation to disk is not supported on NetBSD.')"
    elif [ "$Opmode" == "openbsd" ]; then
       /usr/sbin/apm -Z
    fi
@@ -99,13 +112,13 @@ function hybrid_suspend
    elif [ "$Opmode" == "systemd" ]; then
       systemctl hybrid-sleep -i
    elif [ "$Opmode" == "acpiconf" ]; then
-      echo "Not available on $OS." >&2
+      printf "$(nscde_gettext 'Not available on %s.')\n" "$OS" >&2
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: hybrid suspend is not supported on NetBSD."
+      printf '%s\n' "$(nscde_gettext 'Notice: hybrid suspend is not supported on NetBSD.')"
    elif [ "$Opmode" == "openbsd" ]; then
-      echo "Notice: hybrid suspend is not supported on OpenBSD."
+      printf '%s\n' "$(nscde_gettext 'Notice: hybrid suspend is not supported on OpenBSD.')"
    fi
 }
 
@@ -153,7 +166,7 @@ function f_reboot
 
 function usage
 {
-   echo "Usage: ${0##*/} [ suspend | hibernate | hybrid-suspend | poweroff | reboot ] [ opmode ]"
+   printf "$(nscde_gettext 'Usage: %s [ suspend | hibernate | hybrid-suspend | poweroff | reboot ] [ opmode ]')\n" "${0##*/}"
    exit 0
 }
 

--- a/nscde_tools/acpimgr.in
+++ b/nscde_tools/acpimgr.in
@@ -53,7 +53,7 @@ elif [ "$OS" == "OpenBSD" ]; then
 else
    Opmode=$2
    if [ "x$Opmode" == "x" ]; then
-      echo "Error: Unknown ACPI operation mode."
+      echo "Error: unknown ACPI operation mode."
       exit 4
    fi
 fi
@@ -86,7 +86,7 @@ function hibernate
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: Hibernate to disk is not supported on NetBSD."
+      echo "Notice: hibernation to disk is not supported on NetBSD."
    elif [ "$Opmode" == "openbsd" ]; then
       /usr/sbin/apm -Z
    fi
@@ -99,13 +99,13 @@ function hybrid_suspend
    elif [ "$Opmode" == "systemd" ]; then
       systemctl hybrid-sleep -i
    elif [ "$Opmode" == "acpiconf" ]; then
-      echo "Not available on $OS" >&2
+      echo "Not available on $OS." >&2
    elif [ "$Opmode" == "sunos" ]; then
       pfexec sys-suspend -n
    elif [ "$Opmode" == "netbsd" ]; then
-      echo "Notice: Hybrid suspend is not supported on NetBSD."
+      echo "Notice: hybrid suspend is not supported on NetBSD."
    elif [ "$Opmode" == "openbsd" ]; then
-      echo "Notice: Hybrid suspend is not supported on OpenBSD."
+      echo "Notice: hybrid suspend is not supported on OpenBSD."
    fi
 }
 
@@ -182,4 +182,3 @@ case $Action in
       usage
    ;;
 esac
-

--- a/nscde_tools/backdropmgr.in
+++ b/nscde_tools/backdropmgr.in
@@ -7,7 +7,7 @@
 #
 
 # NsCDE: colormgr shell script
-# BackdropMgr FvwmScript backgroud worker
+# BackdropMgr FvwmScript background worker
 
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
@@ -20,7 +20,7 @@ EchoInfo=0
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot source ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
    exit 1
 fi
 
@@ -163,7 +163,7 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: convert of photo $PhotoNamePath did not suceeded."
+               echo "Error: could not convert photo $PhotoNamePath."
             fi
             OldBackdrop=$(egrep "Colorset 3${Desk}( bg ${bgcs},)? (Tiled|Aspect)?Pixmap (.*)" "${FVWM_USERDIR}/Backdrops.fvwmgen")
             sededpath=$(echo "$ConvertedPhoto" | sed 's/\//\\\//g')
@@ -172,7 +172,7 @@ function GeneratePhotoPreview
                rm -f "${FVWM_USERDIR}/backer/${OldBackdrop##*/}"
             fi
          else
-            echo "Error getting image path for $1."
+            echo "Error: could not get the image path for $1."
          fi
       else
          if [ -s "$PhotoNamePath" ]; then
@@ -184,12 +184,12 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: convert of photo $PhotoNamePath did not suceeded."
+               echo "Error: could not convert photo $PhotoNamePath."
             fi
             bgcs_clean=$(echo "${bgcs}" | sed 's/\\//g')
             echo "Colorset 3${Desk} bg ${bgcs_clean}, $PixmapVariant $ConvertedPhoto" >> ${FVWM_USERDIR}/Backdrops.fvwmgen
          else
-            echo "Error getting image path for $1."
+            echo "Error: could not get the image path for $1."
          fi
       fi
 

--- a/nscde_tools/backdropmgr.in
+++ b/nscde_tools/backdropmgr.in
@@ -7,20 +7,34 @@
 #
 
 # NsCDE: colormgr shell script
-# BackdropMgr FvwmScript background worker
+# BackdropMgr FvwmScript backgroud worker
 
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+# Keep numeric and sort output stable without overriding the user's message locale.
+export LC_NUMERIC=C
+export LC_COLLATE=C
 
 # Defaults for -t and -e.
 PreviewMode=0
 EchoInfo=0
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Load common functions
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   printf "$(nscde_gettext 'Error: cannot load %s.')\n" "${NSCDE_TOOLSDIR}/style_managers.shlib"
    exit 1
 fi
 
@@ -32,7 +46,7 @@ fi
 function CheckBackdrop
 {
    if [ -x $(type -p file) ]; then
-      file $1 | grep -q 'X pixmap image'
+      LC_ALL=C file "$1" | grep -q 'X pixmap image'
       if (($? == 0)); then
          echo "xpixmap"
       else
@@ -163,7 +177,7 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: could not convert photo $PhotoNamePath."
+               printf "$(nscde_gettext 'Error: could not convert photo %s.')\n" "$PhotoNamePath"
             fi
             OldBackdrop=$(egrep "Colorset 3${Desk}( bg ${bgcs},)? (Tiled|Aspect)?Pixmap (.*)" "${FVWM_USERDIR}/Backdrops.fvwmgen")
             sededpath=$(echo "$ConvertedPhoto" | sed 's/\//\\\//g')
@@ -172,7 +186,7 @@ function GeneratePhotoPreview
                rm -f "${FVWM_USERDIR}/backer/${OldBackdrop##*/}"
             fi
          else
-            echo "Error: could not get the image path for $1."
+            printf "$(nscde_gettext 'Error: could not get the image path for %s.')\n" "$1"
          fi
       else
          if [ -s "$PhotoNamePath" ]; then
@@ -184,12 +198,12 @@ function GeneratePhotoPreview
             if (($? == 0)) then
                ConvertedPhoto="$[FVWM_USERDIR]/backer/Desk${Desk}-${PhotoNamePath##*/}"
             else
-               echo "Error: could not convert photo $PhotoNamePath."
+               printf "$(nscde_gettext 'Error: could not convert photo %s.')\n" "$PhotoNamePath"
             fi
             bgcs_clean=$(echo "${bgcs}" | sed 's/\\//g')
             echo "Colorset 3${Desk} bg ${bgcs_clean}, $PixmapVariant $ConvertedPhoto" >> ${FVWM_USERDIR}/Backdrops.fvwmgen
          else
-            echo "Error: could not get the image path for $1."
+            printf "$(nscde_gettext 'Error: could not get the image path for %s.')\n" "$1"
          fi
       fi
 
@@ -276,7 +290,7 @@ do
          GetBackdropByNumber $OPTARG
       ;;
       h)
-         echo "Usage: ${0##*/} <options ...>"
+         printf "$(nscde_gettext 'Usage: %s <options ...>')\n" "${0##*/}"
       ;;
    esac
 done

--- a/nscde_tools/bootstrap.in
+++ b/nscde_tools/bootstrap.in
@@ -801,14 +801,14 @@ function setup_nscde
    fi
 
    locale_terminal_program_in=$(gettext -s "terminal program in")
-   locale_or_leave_autodiscovery=$(gettext -s "or leave autodiscovery")
+   locale_or_leave_autodiscovery=$(gettext -s "or leave autodiscovery.")
    locale_Hint_See=$(gettext -s "Hint: See")
    locale_for_Gkrellm_X_session_and=$(gettext -s "for Gkrellm, X session and")
    sleep 1
    gettext -s '... done!'
    echo ""
    gettext -s "You can set \$[infostore.terminal] variable to your favorite"
-   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf ${locale_or_leave_autodiscovery}."
+   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf ${locale_or_leave_autodiscovery}"
    echo ""
    echo "$locale_Hint_See $NSCDE_DATADIR/examples $locale_for_Gkrellm_X_session_and"
    gettext -s "other integration options you may want to apply."
@@ -848,4 +848,3 @@ do
    ;;
    esac
 done
-

--- a/nscde_tools/bootstrap.in
+++ b/nscde_tools/bootstrap.in
@@ -801,14 +801,14 @@ function setup_nscde
    fi
 
    locale_terminal_program_in=$(gettext -s "terminal program in")
-   locale_or_leave_autodiscovery=$(gettext -s "or leave autodiscovery.")
+   locale_or_leave_autodiscovery=$(gettext -s " or leave autodiscovery.")
    locale_Hint_See=$(gettext -s "Hint: See")
    locale_for_Gkrellm_X_session_and=$(gettext -s "for Gkrellm, X session and")
    sleep 1
    gettext -s '... done!'
    echo ""
    gettext -s "You can set \$[infostore.terminal] variable to your favorite"
-   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf ${locale_or_leave_autodiscovery}"
+   echo "$locale_terminal_program_in \$HOME/.NsCDE/NsCDE.conf${locale_or_leave_autodiscovery}"
    echo ""
    echo "$locale_Hint_See $NSCDE_DATADIR/examples $locale_for_Gkrellm_X_session_and"
    gettext -s "other integration options you may want to apply."
@@ -844,7 +844,9 @@ do
       setup_nscde initial
    ;;
    h)
-      echo "Usage: ${0##*/} [ -r ] [ -i ] [ -h ]"
+      locale_usage=$(gettext -s 'Usage: %s [ -r ] [ -i ] [ -h ]')
+      printf "$locale_usage\n" "${0##*/}"
+      exit 0
    ;;
    esac
 done

--- a/nscde_tools/chtheme.in
+++ b/nscde_tools/chtheme.in
@@ -232,7 +232,7 @@ function localsetup
 
 function Usage
 {
-   echo "Usage: ${BaseName} [ -p <Palette Name> ] [ -n <No of Colors> ] [ -5 | -8 ] [ -w ] [ -m ]"
+   echo "Usage: ${BaseName} [ -p <palette name> ] [ -n <number of colors> ] [ -5 | -8 ] [ -w ] [ -m ]"
    echo "               [ -b ] [ -x ] [ -g <gtk2|False,gtk3|False,gtk4|False> ] [ -q qt4,qt5g|qt5k,qt6 ]"
    echo "               [ -l ] [ -r ] [ -R ] [ -h ]"
 
@@ -308,7 +308,7 @@ do
          palette_name="$OPTARG"
          palette_path=$($NSCDE_TOOLSDIR/colormgr -e -c $ncolors -g "$palette_name")
          if [ ! -r "$palette_path" ]; then
-            echo "Palette $palette_name was not found. Path: \"$palette_path\"."
+            echo "Palette $palette_name was not found at $palette_path."
             exit 9
          fi
       ;;
@@ -406,4 +406,3 @@ fi
 if [ "x$ncolors" == "x" ]; then
    Usage Err
 fi
-

--- a/nscde_tools/chtheme.in
+++ b/nscde_tools/chtheme.in
@@ -6,10 +6,23 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 BaseName="${0##*/}"
 
 if [ ! -d "$NSCDE_TOOLSDIR" ]; then
-   echo "Error: NSCDE_TOOLSDIR is not defined."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_TOOLSDIR is not defined.')"
    exit 10
 fi
 
@@ -232,9 +245,9 @@ function localsetup
 
 function Usage
 {
-   echo "Usage: ${BaseName} [ -p <palette name> ] [ -n <number of colors> ] [ -5 | -8 ] [ -w ] [ -m ]"
-   echo "               [ -b ] [ -x ] [ -g <gtk2|False,gtk3|False,gtk4|False> ] [ -q qt4,qt5g|qt5k,qt6 ]"
-   echo "               [ -l ] [ -r ] [ -R ] [ -h ]"
+   printf "$(nscde_gettext 'Usage: %s [ -p <palette name> ] [ -n <number of colors> ] [ -5 | -8 ] [ -w ] [ -m ]')\n" "$BaseName"
+   printf '%s\n' "$(nscde_gettext '               [ -b ] [ -x ] [ -g <gtk2|False,gtk3|False,gtk4|False> ] [ -q qt4,qt5g|qt5k,qt6 ]')"
+   printf '%s\n' "$(nscde_gettext '               [ -l ] [ -r ] [ -R ] [ -h ]')"
 
    if [ "$1" == "Err" ]; then
       exit 1
@@ -308,7 +321,7 @@ do
          palette_name="$OPTARG"
          palette_path=$($NSCDE_TOOLSDIR/colormgr -e -c $ncolors -g "$palette_name")
          if [ ! -r "$palette_path" ]; then
-            echo "Palette $palette_name was not found at $palette_path."
+            printf "$(nscde_gettext 'Palette %s was not found at %s.')\n" "$palette_name" "$palette_path"
             exit 9
          fi
       ;;

--- a/nscde_tools/colorconv.in
+++ b/nscde_tools/colorconv.in
@@ -9,6 +9,12 @@
 import colorsys
 import sys
 import getopt
+import gettext
+import os
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 def hsv2rgb(hsv1, hsv2, hsv3):
    hsv1 = float(hsv1)
@@ -36,7 +42,7 @@ def rgb2hex(rgb1, rgb2, rgb3, x11_16_bit):
       print ('%01s%02x%02x%02x%02x%02x%02x' % ("#", rgb1, rgb1, rgb2, rgb2, rgb3, rgb3))
 
 def usage():
-    print ("Usage: colorconv [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help")
+    print (_("Usage: colorconv [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help"))
 
 def main():
     try:

--- a/nscde_tools/colorconv.in
+++ b/nscde_tools/colorconv.in
@@ -36,7 +36,7 @@ def rgb2hex(rgb1, rgb2, rgb3, x11_16_bit):
       print ('%01s%02x%02x%02x%02x%02x%02x' % ("#", rgb1, rgb1, rgb2, rgb2, rgb3, rgb3))
 
 def usage():
-    print ("colorcalc [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help")
+    print ("Usage: colorconv [ -R | --rgb <R/G/B> ] | [ -H | --hsv <H/S/V> ] | -x | -X | --hex <R/G/B> | -h | --help")
 
 def main():
     try:
@@ -68,4 +68,3 @@ def main():
 # Action ...
 if __name__ == '__main__':
     main()
-

--- a/nscde_tools/colormgr.in
+++ b/nscde_tools/colormgr.in
@@ -7,10 +7,11 @@
 #
 
 # NsCDE: colormgr shell script
-# ColorMgr FvwmScript background worker
+# ColorMgr FvwmScript backgroud worker
 
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+# Keep numeric and sort output stable without overriding the user's message locale.
+export LC_NUMERIC=C
+export LC_COLLATE=C
 
 # Defaults for -t and -e.
 PreviewMode=0
@@ -18,11 +19,24 @@ EchoInfo=0
 FpVariant=5
 WsmVariant=0
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Load common functions
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   printf "$(nscde_gettext 'Error: cannot load %s.')\n" "${NSCDE_TOOLSDIR}/style_managers.shlib"
    exit 1
 fi
 
@@ -50,7 +64,7 @@ function GenFullPalette
 
       echo ${FVWM_USERDIR}/tmp/_fullpalette.xpm
    else
-      echo "Error: cannot open ${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm."
+      printf "$(nscde_gettext 'Error: cannot open %s.')\n" "${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm"
       exit 3
    fi
 }
@@ -467,7 +481,7 @@ do
          if (($PreviewMode == 0)); then
             ProgBits
          else
-            echo "Pixmap modification is disabled in preview mode."
+            printf '%s\n' "$(nscde_gettext 'Pixmap modification is disabled in preview mode.')"
          fi
       ;;
       b)
@@ -477,7 +491,7 @@ do
          Xresources
       ;;
       h)
-         echo "Usage: ${0##*/} <options> ..."
+         printf "$(nscde_gettext 'Usage: %s <options> ...')\n" "${0##*/}"
       ;;
    esac
 done

--- a/nscde_tools/colormgr.in
+++ b/nscde_tools/colormgr.in
@@ -7,7 +7,7 @@
 #
 
 # NsCDE: colormgr shell script
-# ColorMgr FvwmScript backgroud worker
+# ColorMgr FvwmScript background worker
 
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
@@ -22,7 +22,7 @@ WsmVariant=0
 if [ -f "${NSCDE_TOOLSDIR}/style_managers.shlib" ]; then
    . ${NSCDE_TOOLSDIR}/style_managers.shlib
 else
-   echo "Error: cannot source ${NSCDE_TOOLSDIR}/style_managers.shlib."
+   echo "Error: cannot load ${NSCDE_TOOLSDIR}/style_managers.shlib."
    exit 1
 fi
 
@@ -50,7 +50,7 @@ function GenFullPalette
 
       echo ${FVWM_USERDIR}/tmp/_fullpalette.xpm
    else
-      echo "Error: Cannot open ${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm"
+      echo "Error: cannot open ${NSCDE_DATADIR}/config_templates/progbits/FullPalette.xpm."
       exit 3
    fi
 }
@@ -467,7 +467,7 @@ do
          if (($PreviewMode == 0)); then
             ProgBits
          else
-            echo "Not performing pixmap modification in preview mode."
+            echo "Pixmap modification is disabled in preview mode."
          fi
       ;;
       b)
@@ -481,4 +481,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/confget.in
+++ b/nscde_tools/confget.in
@@ -6,10 +6,14 @@
 # Licence: GPLv3
 #
 
-import configparser, getopt, os, sys, re
+import configparser, getopt, os, sys, re, gettext
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 def usage():
-    print ("Usage: confget -c <file> [ -s <section> ] -k <key> [ -h ]")
+    print (_("Usage: confget -c <file> [ -s <section> ] -k <key> [ -h ]"))
 
 def cmdoptions():
     section = ''

--- a/nscde_tools/confget.in
+++ b/nscde_tools/confget.in
@@ -9,7 +9,7 @@
 import configparser, getopt, os, sys, re
 
 def usage():
-    print ("confget [ -c <file> [ -s <section> ] -k <key> [ -h ]")
+    print ("Usage: confget -c <file> [ -s <section> ] -k <key> [ -h ]")
 
 def cmdoptions():
     section = ''
@@ -75,4 +75,3 @@ def main ():
 if __name__ == '__main__':
     cmdoptions()
     main()
-

--- a/nscde_tools/confset.in
+++ b/nscde_tools/confset.in
@@ -6,10 +6,14 @@
 # Licence: GPLv3
 #
 
-import configparser, getopt, os, sys, re
+import configparser, getopt, os, sys, re, gettext
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 def usage():
-    print ("Usage: confset -c <file> [ -t <properties|ini> ] [ -s <section> ] -k <key> [ -v <value> | -r ] [ -h ]")
+    print (_("Usage: confset -c <file> [ -t <properties|ini> ] [ -s <section> ] -k <key> [ -v <value> | -r ] [ -h ]"))
 
 def cmdoptions():
     section = ''
@@ -72,7 +76,7 @@ def main ():
                 parser.set(section, key, value)
         except configparser.NoSectionError:
             if not removekey:
-                print ("Section " + section + " does not exist; creating it.")
+                print (_("Section %s does not exist; creating it.") % section)
                 parser.add_section(section)
                 parser.set(section, key, value)
 
@@ -99,7 +103,7 @@ def main ():
                             cff.write(dkey + '=' + val)
             cff.close()
         except:
-            print ("Cannot open " + conffile + "; trying to create it.")
+            print (_("Cannot open %s; trying to create it.") % conffile)
             fh = open(conffile, 'w')
             fh.write(key + ' = ' + value + '\n')
             fh.close()

--- a/nscde_tools/confset.in
+++ b/nscde_tools/confset.in
@@ -9,7 +9,7 @@
 import configparser, getopt, os, sys, re
 
 def usage():
-    print ("confset [ -c <file> -t [ properties|ini ] [ -s <section> ] -k <key> -v <value> | [ -h ]")
+    print ("Usage: confset -c <file> [ -t <properties|ini> ] [ -s <section> ] -k <key> [ -v <value> | -r ] [ -h ]")
 
 def cmdoptions():
     section = ''
@@ -72,7 +72,7 @@ def main ():
                 parser.set(section, key, value)
         except configparser.NoSectionError:
             if not removekey:
-                print ("No section named " + section + " creating it.")
+                print ("Section " + section + " does not exist; creating it.")
                 parser.add_section(section)
                 parser.set(section, key, value)
 
@@ -99,7 +99,7 @@ def main ():
                             cff.write(dkey + '=' + val)
             cff.close()
         except:
-            print ("Cannot open file", conffile, "trying to create it.")
+            print ("Cannot open " + conffile + "; trying to create it.")
             fh = open(conffile, 'w')
             fh.write(key + ' = ' + value + '\n')
             fh.close()
@@ -108,4 +108,3 @@ def main ():
 if __name__ == '__main__':
     cmdoptions()
     main()
-

--- a/nscde_tools/fontmgr.in
+++ b/nscde_tools/fontmgr.in
@@ -6,19 +6,32 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 if [ -z $NSCDE_ROOT ]; then
-   echo "Error: NSCDE_ROOT is not set. Exiting."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_ROOT is not set. Exiting.')"
    exit 2
 fi
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "Error: NSCDE_DATADIR is not set. Exiting."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_DATADIR is not set. Exiting.')"
    exit 2
 fi
 
 type -p fc-list > /dev/null
 if (($? != 0)); then
-   echo "Error: the fc-list command was not found."
+   printf '%s\n' "$(nscde_gettext 'Error: the fc-list command was not found.')"
    exit 3
 fi
 
@@ -31,12 +44,12 @@ FNUMS=$(echo "$FNAMES" | sort -u | grep -En '.*')
 function findfontsets
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "NSCDE_ROOT is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_ROOT is not defined. Exiting.')"
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "NSCDE_DATADIR is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_DATADIR is not defined. Exiting.')"
       exit 2
    fi
 
@@ -330,7 +343,7 @@ do
          miscintegrations
       ;;
       h)
-         echo "Usage: ${0##*/} [ -pP ] [ -F <font-set number> ] [ -f <font-set name> ] [ -gGnN <value> ] [ -s <style> ] [ -rXmTQM <value> ] [ -h ]"
+         printf "$(nscde_gettext 'Usage: %s [ -pP ] [ -F <font-set number> ] [ -f <font-set name> ] [ -gGnN <value> ] [ -s <style> ] [ -rXmTQM <value> ] [ -h ]')\n" "${0##*/}"
       ;;
    esac
 done

--- a/nscde_tools/fontmgr.in
+++ b/nscde_tools/fontmgr.in
@@ -18,7 +18,7 @@ fi
 
 type -p fc-list > /dev/null
 if (($? != 0)); then
-   echo "Error: fc-list command not found."
+   echo "Error: the fc-list command was not found."
    exit 3
 fi
 
@@ -31,12 +31,12 @@ FNUMS=$(echo "$FNAMES" | sort -u | grep -En '.*')
 function findfontsets
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -330,8 +330,7 @@ do
          miscintegrations
       ;;
       h)
-         echo "Usage: ..."
+         echo "Usage: ${0##*/} [ -pP ] [ -F <font-set number> ] [ -f <font-set name> ] [ -gGnN <value> ] [ -s <style> ] [ -rXmTQM <value> ] [ -h ]"
       ;;
    esac
 done
-

--- a/nscde_tools/fp_manage_subpanel.in
+++ b/nscde_tools/fp_manage_subpanel.in
@@ -1,39 +1,39 @@
 #!@KSH@
 
 if [ -z $HOME ]; then
-   echo "Error: HOME is not set cannot continue."
+   echo "Error: HOME is not set; cannot continue."
    exit 3
 fi
 
 if [ -z $NSCDE_ROOT ]; then
-   echo "Error: NSCDE_ROOT is not set cannot continue."
+   echo "Error: NSCDE_ROOT is not set; cannot continue."
    exit 4
 fi
 
 if [ ! -e "$NSCDE_ROOT" ]; then
-   echo "Error: NSCDE_ROOT does not exist. Cannot continue."
+   echo "Error: NSCDE_ROOT does not exist; cannot continue."
    exit 5
 fi
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "Error: NSCDE_DATADIR is not set cannot continue."
+   echo "Error: NSCDE_DATADIR is not set; cannot continue."
    exit 4
 fi
 
 if [ ! -e "$NSCDE_DATADIR" ]; then
-   echo "Error: NSCDE_DATADIR does not exist. Cannot continue."
+   echo "Error: NSCDE_DATADIR does not exist; cannot continue."
    exit 5
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "Error: FVWM_USERDIR is not set cannot continue."
+   echo "Error: FVWM_USERDIR is not set; cannot continue."
    exit 6
 fi
 
 function add_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "ERROR: Missing subpanel number."
+      echo "Error: missing subpanel number."
       exit 9
    fi
 
@@ -47,7 +47,7 @@ function add_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,0/S${SubpanelNo},ENABLED,1/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "ERROR: Cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
          exit 8
       fi
    fi
@@ -56,7 +56,7 @@ function add_subpanel
 function delete_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "ERROR: Missing subpanel number."
+      echo "Error: missing subpanel number."
       exit 9
    fi
 
@@ -70,7 +70,7 @@ function delete_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,1/S${SubpanelNo},ENABLED,0/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "ERROR: Cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
          exit 8
       fi
    fi
@@ -340,7 +340,7 @@ do
          SubpLocalDefCheck=$(egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED),.*" "$FVWM_USERDIR/Subpanels.actions" 2>/dev/null | wc -l)
 
          if (($SubpLocalDefCheck != 0)) && (($SubpLocalDefCheck != 3)); then
-            echo "ERROR: invalid configuration for subpanel ${SubpanelNo} in $FVWM_USERDIR/Subpanels.actions."
+            echo "Error: invalid configuration for subpanel ${SubpanelNo} in $FVWM_USERDIR/Subpanels.actions."
             exit 7
          fi
       ;;
@@ -374,4 +374,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/fp_manage_subpanel.in
+++ b/nscde_tools/fp_manage_subpanel.in
@@ -1,39 +1,52 @@
 #!@KSH@
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 if [ -z $HOME ]; then
-   echo "Error: HOME is not set; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: HOME is not set; cannot continue.')"
    exit 3
 fi
 
 if [ -z $NSCDE_ROOT ]; then
-   echo "Error: NSCDE_ROOT is not set; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_ROOT is not set; cannot continue.')"
    exit 4
 fi
 
 if [ ! -e "$NSCDE_ROOT" ]; then
-   echo "Error: NSCDE_ROOT does not exist; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_ROOT does not exist; cannot continue.')"
    exit 5
 fi
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "Error: NSCDE_DATADIR is not set; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_DATADIR is not set; cannot continue.')"
    exit 4
 fi
 
 if [ ! -e "$NSCDE_DATADIR" ]; then
-   echo "Error: NSCDE_DATADIR does not exist; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: NSCDE_DATADIR does not exist; cannot continue.')"
    exit 5
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "Error: FVWM_USERDIR is not set; cannot continue."
+   printf '%s\n' "$(nscde_gettext 'Error: FVWM_USERDIR is not set; cannot continue.')"
    exit 6
 fi
 
 function add_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "Error: missing subpanel number."
+      printf '%s\n' "$(nscde_gettext 'Error: missing subpanel number.')"
       exit 9
    fi
 
@@ -47,7 +60,7 @@ function add_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,0/S${SubpanelNo},ENABLED,1/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         printf "$(nscde_gettext 'Error: cannot open %s for reading.')\n" "$NSCDE_DATADIR/defaults/Subpanels.actions"
          exit 8
       fi
    fi
@@ -56,7 +69,7 @@ function add_subpanel
 function delete_subpanel
 {
    if [ "x$SubpanelNo" == "x" ]; then
-      echo "Error: missing subpanel number."
+      printf '%s\n' "$(nscde_gettext 'Error: missing subpanel number.')"
       exit 9
    fi
 
@@ -70,7 +83,7 @@ function delete_subpanel
          egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED|ENTRY),.*" "$NSCDE_DATADIR/defaults/Subpanels.actions" >> "$FVWM_USERDIR/Subpanels.actions"
          $NSCDE_TOOLSDIR/ised -c "s/^S${SubpanelNo},ENABLED,1/S${SubpanelNo},ENABLED,0/g" -f "$FVWM_USERDIR/Subpanels.actions"
       else
-         echo "Error: cannot open $NSCDE_DATADIR/defaults/Subpanels.actions for reading."
+         printf "$(nscde_gettext 'Error: cannot open %s for reading.')\n" "$NSCDE_DATADIR/defaults/Subpanels.actions"
          exit 8
       fi
    fi
@@ -340,7 +353,7 @@ do
          SubpLocalDefCheck=$(egrep "^S${SubpanelNo},(NAME|WIDTH|ENABLED),.*" "$FVWM_USERDIR/Subpanels.actions" 2>/dev/null | wc -l)
 
          if (($SubpLocalDefCheck != 0)) && (($SubpLocalDefCheck != 3)); then
-            echo "Error: invalid configuration for subpanel ${SubpanelNo} in $FVWM_USERDIR/Subpanels.actions."
+            printf "$(nscde_gettext 'Error: invalid configuration for subpanel %s in %s.')\n" "$SubpanelNo" "$FVWM_USERDIR/Subpanels.actions"
             exit 7
          fi
       ;;

--- a/nscde_tools/fpdoc.in
+++ b/nscde_tools/fpdoc.in
@@ -33,7 +33,7 @@ function find_cmd_in_subpanel
          exit 0
       fi
    else
-      echo "Error: ${0##*/}: Empty subpanel search for line ${LineInSubpanel} in subpanel ${SubpanelNo}"
+      echo "Error: ${0##*/}: no entry found for line ${LineInSubpanel} in subpanel ${SubpanelNo}."
       exit 1
    fi
 }
@@ -55,7 +55,7 @@ elif [ "$Mode" == "-rsubp" ]; then
    RawMan=1
    find_cmd_in_subpanel
 else
-   echo "Error: ${0##*/}: Unknown mode of operation."
+   echo "Error: ${0##*/}: unknown operation mode."
    exit 1
 fi
 
@@ -285,4 +285,3 @@ if (($MANRET != 0)); then
       fi
    fi
 fi
-

--- a/nscde_tools/fpdoc.in
+++ b/nscde_tools/fpdoc.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Called from f_FrontPanelPropsMenu and f_SubpanelPropsMenu to
 # populate Help menu item as best as it can with fuzzy finding
 # internal docs or man pages.
@@ -33,7 +46,7 @@ function find_cmd_in_subpanel
          exit 0
       fi
    else
-      echo "Error: ${0##*/}: no entry found for line ${LineInSubpanel} in subpanel ${SubpanelNo}."
+      printf "$(nscde_gettext 'Error: %s: no entry found for line %s in subpanel %s.')\n" "${0##*/}" "$LineInSubpanel" "$SubpanelNo"
       exit 1
    fi
 }
@@ -55,13 +68,11 @@ elif [ "$Mode" == "-rsubp" ]; then
    RawMan=1
    find_cmd_in_subpanel
 else
-   echo "Error: ${0##*/}: unknown operation mode."
+   printf "$(nscde_gettext 'Error: %s: unknown operation mode.')\n" "${0##*/}"
    exit 1
 fi
 
 OS=$(uname -s)
-
-echo "Echo Debug ========> Fpdoc string we parse: $Str"
 
 if [ "x$TMPDIR" == "x" ]; then
    TMPDIR=${FVWM_USERDIR}/tmp

--- a/nscde_tools/generate_app_menus.in
+++ b/nscde_tools/generate_app_menus.in
@@ -46,8 +46,7 @@ if (($file_err == 0)); then
       curr_res="${res}"
    done
 else
-   echo "${0##*/}: No valid applications menus file found." >&2
+   echo "${0##*/}: no valid application-menu file was found." >&2
 fi
 
 echo "+ I InfoStoreRemove menuitem.clres"
-

--- a/nscde_tools/generate_app_menus.in
+++ b/nscde_tools/generate_app_menus.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 funcname=$1
 menuname=$2
 
@@ -46,7 +59,7 @@ if (($file_err == 0)); then
       curr_res="${res}"
    done
 else
-   echo "${0##*/}: no valid application-menu file was found." >&2
+   printf "$(nscde_gettext '%s: no valid application-menu file was found.')\n" "${0##*/}" >&2
 fi
 
 echo "+ I InfoStoreRemove menuitem.clres"

--- a/nscde_tools/generate_subpanels.in
+++ b/nscde_tools/generate_subpanels.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 while getopts wfsh OPT
 do
    case $OPT in
@@ -19,7 +32,8 @@ do
       SYSMODE=1
    ;;
    h)
-      echo "Usage: ${0##*/} [ -w ] [ -f ] [ -h ]"
+      printf "$(nscde_gettext 'Usage: %s [ -w ] [ -f ] [ -h ]')\n" "${0##*/}"
+      exit 0
    ;;
    esac
 done
@@ -30,7 +44,7 @@ fi
 
 if [ -z $FVWM_USERDIR ]; then
    if [[ -z $SYSMODE ]]; then
-      echo "Error: FVWM_USERDIR is not set."
+      printf '%s\n' "$(nscde_gettext 'Error: FVWM_USERDIR is not set.')"
       exit 2
    fi
 fi
@@ -175,4 +189,3 @@ do
       ((id = id + 1))
    done
 done
-

--- a/nscde_tools/get_logical_screens.in
+++ b/nscde_tools/get_logical_screens.in
@@ -34,7 +34,7 @@ function defaultcf
 # Without xrandr(1) we cannot continue.
 type -qp xrandr
 if (($? != 0)); then
-   echo "${0##*/}: xrandr command is not available in PATH. Setting default one monitor setup." >&2
+   echo "${0##*/}: xrandr is not available in PATH; using a single-monitor setup." >&2
    defaultcf
    exit 0
 fi
@@ -46,7 +46,7 @@ mdata=$(xrandr --listmonitors)
 # for this Xinerama/SLS support.
 screencnt=$(echo "$xdata" | wc -l)
 if (($screencnt > 1)); then
-   echo "${0##*/}: More than one local screen handling is not yet tested and hence not supported." >&2
+   echo "${0##*/}: multiple local X screens are not currently supported." >&2
    defaultcf
    exit 0
 fi
@@ -81,7 +81,7 @@ if (($? == 0)); then
       echo "InfoStoreAdd lscrn.cnt $moncnt"
    fi
 else
-   echo "${0##*/}: Error in handling monitor count: \"$moncnt\""
+   echo "${0##*/}: invalid monitor count: $moncnt."
    defaultcf
    exit 0
 fi
@@ -133,7 +133,7 @@ do
          rootmenudata=$(@ECHONE@ "$rootmenudata\nAddToMenu m_SlsMoveAll \"Move To Logical Screen: &${scnum} ($[infostore.lscrn.${scrvar}.name]) ...\"           All MoveToScreen ${scrvar}")
       fi
    else
-      echo "${0##*/}: Error in handling monitor $mname width: (\"$scwidth\") or height (\"$scheight\")" >&2
+      echo "${0##*/}: invalid geometry for monitor $mname (width: $scwidth; height: $scheight)." >&2
       defaultcf
       break
    fi
@@ -216,4 +216,3 @@ if [ "x${check_fvwm3}" == "x1" ] ; then
       done < "$UserBackdropsFile"
    fi
 fi
-

--- a/nscde_tools/get_logical_screens.in
+++ b/nscde_tools/get_logical_screens.in
@@ -11,6 +11,19 @@
 # and export this as FVWM infostore variables for use in FVWM
 # On a cloned display, this will simply return one global size
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 IFS=" "
 check_fvwm3=${FVWM_IS_FVWM3}
 
@@ -34,7 +47,7 @@ function defaultcf
 # Without xrandr(1) we cannot continue.
 type -qp xrandr
 if (($? != 0)); then
-   echo "${0##*/}: xrandr is not available in PATH; using a single-monitor setup." >&2
+   printf "$(nscde_gettext '%s: xrandr is not available in PATH; using a single-monitor setup.')\n" "${0##*/}" >&2
    defaultcf
    exit 0
 fi
@@ -46,7 +59,7 @@ mdata=$(xrandr --listmonitors)
 # for this Xinerama/SLS support.
 screencnt=$(echo "$xdata" | wc -l)
 if (($screencnt > 1)); then
-   echo "${0##*/}: multiple local X screens are not currently supported." >&2
+   printf "$(nscde_gettext '%s: multiple local X screens are not currently supported.')\n" "${0##*/}" >&2
    defaultcf
    exit 0
 fi
@@ -81,7 +94,7 @@ if (($? == 0)); then
       echo "InfoStoreAdd lscrn.cnt $moncnt"
    fi
 else
-   echo "${0##*/}: invalid monitor count: $moncnt."
+   printf "$(nscde_gettext '%s: invalid monitor count: %s.')\n" "${0##*/}" "$moncnt"
    defaultcf
    exit 0
 fi
@@ -130,10 +143,10 @@ do
          echo "InfoStoreAdd lscrn.${scrvar}.pos.x $scpos_x"
          echo "InfoStoreAdd lscrn.${scrvar}.pos.y $scpos_y"
          echo "InfoStoreAdd lscrn.${scrvar}.name $mname"
-         rootmenudata=$(@ECHONE@ "$rootmenudata\nAddToMenu m_SlsMoveAll \"Move To Logical Screen: &${scnum} ($[infostore.lscrn.${scrvar}.name]) ...\"           All MoveToScreen ${scrvar}")
+         rootmenudata=$(@ECHONE@ "$rootmenudata\nAddToMenu m_SlsMoveAll \"\$[gt.Move To Logical Screen:] &${scnum} ($[infostore.lscrn.${scrvar}.name]) ...\"           All MoveToScreen ${scrvar}")
       fi
    else
-      echo "${0##*/}: invalid geometry for monitor $mname (width: $scwidth; height: $scheight)." >&2
+      printf "$(nscde_gettext '%s: invalid geometry for monitor %s (width: %s; height: %s).')\n" "${0##*/}" "$mname" "$scwidth" "$scheight" >&2
       defaultcf
       break
    fi
@@ -144,7 +157,7 @@ if (($scpos_sum > 0)); then
    echo ""
    echo "DestroyMenu m_SlsMoveAll"
    echo "AddToMenu m_SlsMoveAll"
-   echo "+ \"&Move All Windows To This Screen\"            f_MoveAllToThisScreen"
+   echo '+ "$[gt.&Move All Windows To This Screen]"            f_MoveAllToThisScreen'
    echo "+ \"\" Nop"
    echo "$rootmenudata" | egrep -v '^$'
 

--- a/nscde_tools/getfont.in
+++ b/nscde_tools/getfont.in
@@ -13,12 +13,12 @@ PrintFnSize=0
 PrettyName=0
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "No \$NSCDE_DATADIR set. Exiting."
+   echo "NSCDE_DATADIR is not set. Exiting."
    exit 3
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "No \$FVWM_USERDIR set. Exiting."
+   echo "FVWM_USERDIR is not set. Exiting."
    exit 4
 fi
 
@@ -62,7 +62,7 @@ function GetFont
          fncnffile="$FnFile"
          sysfncnffile="$FnFile"
       else
-         echo "Error: Cannot read $FnFile"
+         echo "Error: cannot read $FnFile."
          exit 3
       fi
    fi
@@ -204,7 +204,7 @@ do
          export FuncToCall="GetFontset"
       ;;
       h)
-         echo "Usage: ${0##*/} [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z maxsize ] [ -F ] [ -h ]"
+         echo "Usage: ${0##*/} [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z <maximum size> ] [ -F ] [ -h ]"
          exit 0
       ;;
    esac
@@ -215,4 +215,3 @@ if [ "x$FuncToCall" == "xGetFontset" ]; then
 else
    GetFont
 fi
-

--- a/nscde_tools/getfont.in
+++ b/nscde_tools/getfont.in
@@ -6,19 +6,35 @@
 # Licence: GPLv3
 #
 
-export LC_ALL=C
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
+# Font calculations require stable numeric and sorting conventions, but message
+# translation must continue to follow the user's locale.
+export LC_NUMERIC=C
+export LC_COLLATE=C
 
 # Initialize default values for some variables
 PrintFnSize=0
 PrettyName=0
 
 if [ -z $NSCDE_DATADIR ]; then
-   echo "NSCDE_DATADIR is not set. Exiting."
+   printf '%s\n' "$(nscde_gettext 'NSCDE_DATADIR is not set. Exiting.')"
    exit 3
 fi
 
 if [ -z $FVWM_USERDIR ]; then
-   echo "FVWM_USERDIR is not set. Exiting."
+   printf '%s\n' "$(nscde_gettext 'FVWM_USERDIR is not set. Exiting.')"
    exit 4
 fi
 
@@ -62,7 +78,7 @@ function GetFont
          fncnffile="$FnFile"
          sysfncnffile="$FnFile"
       else
-         echo "Error: cannot read $FnFile."
+         printf "$(nscde_gettext 'Error: cannot read %s.')\n" "$FnFile"
          exit 3
       fi
    fi
@@ -204,7 +220,7 @@ do
          export FuncToCall="GetFontset"
       ;;
       h)
-         echo "Usage: ${0##*/} [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z <maximum size> ] [ -F ] [ -h ]"
+         printf "$(nscde_gettext 'Usage: %s [ -f <file> ] [ -v(ariable) | -m(onospaced) ] [ -t <normal | bold | italic> ] [ -s <small | medium | large> ] [ -S ] [ -Z <maximum size> ] [ -F ] [ -h ]')\n" "${0##*/}"
          exit 0
       ;;
    esac

--- a/nscde_tools/ised.in
+++ b/nscde_tools/ised.in
@@ -30,7 +30,7 @@ case $NSCDE_OS in
          if (($? == 0)); then
             SED="sed"
          else
-            echo "Error: ${0##*/}: Cannot find GNU sed."
+            echo "Error: ${0##*/}: cannot find GNU sed."
          exit 4
          fi
       fi
@@ -44,7 +44,7 @@ case $NSCDE_OS in
       if (($? == 0)); then
          SED="gsed"
       else
-         echo "Error: ${0##*/}: Cannot find GNU sed."
+         echo "Error: ${0##*/}: cannot find GNU sed."
          exit 4
       fi
    fi
@@ -67,7 +67,7 @@ do
       TO_STDOUT=1
    ;;
    h)
-      echo "Usage: ${0##*/} -s <sedopts> -c <sedcode> [ -f <inputfile> ] [ -h ]"
+      echo "Usage: ${0##*/} -s <sed options> -c <sed code> [ -f <input file> ] [ -h ]"
       exit 0
    ;;
    esac

--- a/nscde_tools/ised.in
+++ b/nscde_tools/ised.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Wrapper for sed used heavily in FvwmScript scripts
 # We are not using "sed -i" since GNU sed is not present on
 # all systems, specially not under it's original name.
@@ -30,7 +43,7 @@ case $NSCDE_OS in
          if (($? == 0)); then
             SED="sed"
          else
-            echo "Error: ${0##*/}: cannot find GNU sed."
+            printf "$(nscde_gettext 'Error: %s: cannot find GNU sed.')\n" "${0##*/}"
          exit 4
          fi
       fi
@@ -44,7 +57,7 @@ case $NSCDE_OS in
       if (($? == 0)); then
          SED="gsed"
       else
-         echo "Error: ${0##*/}: cannot find GNU sed."
+         printf "$(nscde_gettext 'Error: %s: cannot find GNU sed.')\n" "${0##*/}"
          exit 4
       fi
    fi
@@ -67,7 +80,7 @@ do
       TO_STDOUT=1
    ;;
    h)
-      echo "Usage: ${0##*/} -s <sed options> -c <sed code> [ -f <input file> ] [ -h ]"
+      printf "$(nscde_gettext 'Usage: %s -s <sed options> -c <sed code> [ -f <input file> ] [ -h ]')\n" "${0##*/}"
       exit 0
    ;;
    esac

--- a/nscde_tools/keymenu.in
+++ b/nscde_tools/keymenu.in
@@ -6,13 +6,26 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 KeybindingsType="$2"
 
 if [ "x${KeybindingsType}" == "x" ]; then
-   echo "NsCDE: KeybindingsType is empty; using the default: cua." >&2
-   KeybindingsType="cucuaa"
+   printf '%s\n' "$(nscde_gettext 'NsCDE: KeybindingsType is empty; using the default: cua.')" >&2
+   KeybindingsType="cua"
 else
-   echo "NsCDE: using KeybindingsType ${2}." >&2
+   printf "$(nscde_gettext 'NsCDE: using KeybindingsType %s.')\n" "$KeybindingsType" >&2
 fi
 
 function config_for_menu

--- a/nscde_tools/keymenu.in
+++ b/nscde_tools/keymenu.in
@@ -9,10 +9,10 @@
 KeybindingsType="$2"
 
 if [ "x${KeybindingsType}" == "x" ]; then
-   echo "NsCDE: KeybindingsType was empty, using default: cua." >&2
+   echo "NsCDE: KeybindingsType is empty; using the default: cua." >&2
    KeybindingsType="cucuaa"
 else
-   echo "NsCDE: Using KeybindingsType ${2}." >&2
+   echo "NsCDE: using KeybindingsType ${2}." >&2
 fi
 
 function config_for_menu
@@ -119,4 +119,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/palette_colorgen.in
+++ b/nscde_tools/palette_colorgen.in
@@ -22,6 +22,11 @@ import os
 import sys
 import shutil
 import getopt
+import gettext
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 bg=[0,0,0,0,0,0,0,0,0]
 fg=[0,0,0,0,0,0,0,0,0]
@@ -729,7 +734,7 @@ def gencdecolors(palettefile,n,infile,outdir,fext,shorten_colorhex):
 
 
 def usage():
-    print ("Generate colorsets for FVWM, X resources, backdrops, and interface pixmaps.")
+    print (_("Generate colorsets for FVWM, X resources, backdrops, and interface pixmaps."))
 
 def main():
     shorten_colorhex = 0

--- a/nscde_tools/palette_colorgen.in
+++ b/nscde_tools/palette_colorgen.in
@@ -729,7 +729,7 @@ def gencdecolors(palettefile,n,infile,outdir,fext,shorten_colorhex):
 
 
 def usage():
-    print ("Used to generate colorsets for fvwm, Xresources, backdrops and element pixmaps")
+    print ("Generate colorsets for FVWM, X resources, backdrops, and interface pixmaps.")
 
 def main():
     shorten_colorhex = 0
@@ -816,4 +816,3 @@ def main():
 # Action ...
 if __name__ == '__main__':
     main()
-

--- a/nscde_tools/style_managers.shlib.in
+++ b/nscde_tools/style_managers.shlib.in
@@ -5,19 +5,19 @@
 #
 
 # NsCDE: routines common for Style Managers ColorMgr and BackdropMgr
-# FvwmScript backgroud workers
+# FvwmScript background workers
 
 # Scans system and user path for palettes and stores them in SysPalettes and UserPalettes variables
 # Used in other API functions and in managers
 function FindPalettes
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -36,12 +36,12 @@ function FindPalettes
 function FindBackdrops
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -60,12 +60,12 @@ function FindBackdrops
 function FindPhotos
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "No NSCDE_ROOT defined. Exiting."
+      echo "NSCDE_ROOT is not defined. Exiting."
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "No NSCDE_DATADIR defined. Exiting."
+      echo "NSCDE_DATADIR is not defined. Exiting."
       exit 2
    fi
 
@@ -240,4 +240,3 @@ function GetPaletteByName
       fi
    done
 }
-

--- a/nscde_tools/style_managers.shlib.in
+++ b/nscde_tools/style_managers.shlib.in
@@ -5,19 +5,32 @@
 #
 
 # NsCDE: routines common for Style Managers ColorMgr and BackdropMgr
-# FvwmScript background workers
+# FvwmScript backgroud workers
+
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
 
 # Scans system and user path for palettes and stores them in SysPalettes and UserPalettes variables
 # Used in other API functions and in managers
 function FindPalettes
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "NSCDE_ROOT is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_ROOT is not defined. Exiting.')"
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "NSCDE_DATADIR is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_DATADIR is not defined. Exiting.')"
       exit 2
    fi
 
@@ -36,12 +49,12 @@ function FindPalettes
 function FindBackdrops
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "NSCDE_ROOT is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_ROOT is not defined. Exiting.')"
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "NSCDE_DATADIR is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_DATADIR is not defined. Exiting.')"
       exit 2
    fi
 
@@ -60,12 +73,12 @@ function FindBackdrops
 function FindPhotos
 {
    if [ -z $NSCDE_ROOT ]; then
-      echo "NSCDE_ROOT is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_ROOT is not defined. Exiting.')"
       exit 2
    fi
 
    if [ -z $NSCDE_DATADIR ]; then
-      echo "NSCDE_DATADIR is not defined. Exiting."
+      printf '%s\n' "$(nscde_gettext 'NSCDE_DATADIR is not defined. Exiting.')"
       exit 2
    fi
 

--- a/nscde_tools/subpanel_menuitem_props.in
+++ b/nscde_tools/subpanel_menuitem_props.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # Function: examine_entrypart
 # Purpose: detect and count missing
 # entries until next valid one
@@ -64,14 +77,14 @@ function subpanels_file_tstamp
    REGEN=0
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]; then
-         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen; regenerating the latter." >&2
+         printf "$(nscde_gettext '%s is newer than %s; regenerating the latter.')\n" "$FVWM_USERDIR/Subpanels.actions" "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" >&2
          $NSCDE_TOOLSDIR/generate_subpanels -w > $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen
          REGEN=1
       fi
    fi
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]; then
-         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen; regenerating the latter." >&2
+         printf "$(nscde_gettext '%s is newer than %s; regenerating the latter.')\n" "$FVWM_USERDIR/Subpanels.actions" "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" >&2
          $NSCDE_TOOLSDIR/generate_subpanels -f > $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen
          REGEN=1
       fi
@@ -301,14 +314,14 @@ function manage_entry
             $NSCDE_ROOT/bin/nscde_fvwmclnt "f_Notifier \"Subpanel Properties\" \"Dismiss\" \"NsCDE/Error.xpm\" \
                         \"$[gt.Action for item] '$TITLE' $[gt.not performed on Subpanel] $subpid. $[gt.Errors found in] $tmpfile.\""
          else
-            echo "Action for item $TITLE was not performed on subpanel $subpid; errors were written to $tmpfile." >&2
+            printf "$(nscde_gettext 'Action for item %s was not performed on subpanel %s; errors were written to %s.')\n" "$TITLE" "$subpid" "$tmpfile" >&2
          fi
          exit 2
       fi
    fi
 
    if [ -f "$tmpfile" ]; then
-      echo "Removing stale temporary file $tmpfile." >&2
+      printf "$(nscde_gettext 'Removing stale temporary file %s.')\n" "$tmpfile" >&2
       rm -f "$tmpfile"
    fi
 }
@@ -406,7 +419,7 @@ function copy_to_main_panel
       entry_to_copy=$(egrep -h "^S${subpid},ENTRY,*" "$NSCDE_DATADIR/defaults/Subpanels.actions" | sed -n "${entryid}p")
    fi
    if [ "x$entry_to_copy" == "x" ]; then
-      echo "Error: subpanel_menuitem_props (copy_to_main_panel): no entry in the system Subpanels.actions file."
+      printf '%s\n' "$(nscde_gettext 'Error: subpanel_menuitem_props (copy_to_main_panel): no entry in the system Subpanels.actions file.')"
       exit 10
    fi
    echo "$entry_to_copy" | tail -1 | while IFS="," read smark emark title type icon cmd
@@ -414,7 +427,7 @@ function copy_to_main_panel
       for content in "$title" "$icon" "$cmd"
       do
          if [ "x$content" == "x" ]; then
-            echo "Error: subpanel_menuitem_props (copy_to_main_panel): the title, icon, or command is empty."
+            printf '%s\n' "$(nscde_gettext 'Error: subpanel_menuitem_props (copy_to_main_panel): the title, icon, or command is empty.')"
             exit 10
          fi
       done
@@ -441,7 +454,7 @@ function copy_to_main_panel
 
       # Try find_appropriate_icon with different extensions.
       if (($ENOICON == 1)); then
-         echo "Trying alternate file extensions while searching for an icon ..."
+         printf '%s\n' "$(nscde_gettext 'Trying alternate file extensions while searching for an icon ...')"
          export ENOICON=0
          case "$icon_ext" in
          'png')
@@ -693,7 +706,7 @@ function delete_confirm
 {
    if [[ -n $DISPLAY ]]; then
       $NSCDE_ROOT/bin/nscde_fvwmclnt "f_RunQuickScriptDialog ActionForm \
-                   \"$[gt.Delete item] \\\"$TITLE\\\" $[gt.from the subpanel] ${subpid}?\" \
+                   \"$[gt.Delete item] \\\"$TITLE\\\"? $[gt.Subpanel]: ${subpid}.\" \
                    $[gt.Yes] $[gt.No] \"$[gt.Confirm Entry Deletion]\" \
                    \"f_DeleteFromSubpanel $subpid $entryid\" Nop"
    fi

--- a/nscde_tools/subpanel_menuitem_props.in
+++ b/nscde_tools/subpanel_menuitem_props.in
@@ -64,14 +64,14 @@ function subpanels_file_tstamp
    REGEN=0
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm2.fvwmgen" ]; then
-         echo "File $FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen ... regenerating last one." >&2
+         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen; regenerating the latter." >&2
          $NSCDE_TOOLSDIR/generate_subpanels -w > $FVWM_USERDIR/Subpanels.fvwm2.fvwmgen
          REGEN=1
       fi
    fi
    if [[ -r "$FVWM_USERDIR/Subpanels.actions" && -r "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]]; then
       if [ "$FVWM_USERDIR/Subpanels.actions" -nt "$FVWM_USERDIR/Subpanels.fvwm3.fvwmgen" ]; then
-         echo "File $FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen ... regenerating last one." >&2
+         echo "$FVWM_USERDIR/Subpanels.actions is newer than $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen; regenerating the latter." >&2
          $NSCDE_TOOLSDIR/generate_subpanels -f > $FVWM_USERDIR/Subpanels.fvwm3.fvwmgen
          REGEN=1
       fi
@@ -301,14 +301,14 @@ function manage_entry
             $NSCDE_ROOT/bin/nscde_fvwmclnt "f_Notifier \"Subpanel Properties\" \"Dismiss\" \"NsCDE/Error.xpm\" \
                         \"$[gt.Action for item] '$TITLE' $[gt.not performed on Subpanel] $subpid. $[gt.Errors found in] $tmpfile.\""
          else
-            echo "Action for item $TITLE not performed on Subpanel $subpid. Errors in $tmpfile found." >&2
+            echo "Action for item $TITLE was not performed on subpanel $subpid; errors were written to $tmpfile." >&2
          fi
          exit 2
       fi
    fi
 
    if [ -f "$tmpfile" ]; then
-      echo "Removing stale tmp file $tmpfile" >&2
+      echo "Removing stale temporary file $tmpfile." >&2
       rm -f "$tmpfile"
    fi
 }
@@ -406,7 +406,7 @@ function copy_to_main_panel
       entry_to_copy=$(egrep -h "^S${subpid},ENTRY,*" "$NSCDE_DATADIR/defaults/Subpanels.actions" | sed -n "${entryid}p")
    fi
    if [ "x$entry_to_copy" == "x" ]; then
-      echo "ERROR: subpanel_menuitem_props (copy_to_main_panel): internal error. No entry in system Subpanels.actons file."
+      echo "Error: subpanel_menuitem_props (copy_to_main_panel): no entry in the system Subpanels.actions file."
       exit 10
    fi
    echo "$entry_to_copy" | tail -1 | while IFS="," read smark emark title type icon cmd
@@ -414,7 +414,7 @@ function copy_to_main_panel
       for content in "$title" "$icon" "$cmd"
       do
          if [ "x$content" == "x" ]; then
-            echo "ERROR: subpanel_menuitem_props (copy_to_main_panel): empty title, icon or command definition."
+            echo "Error: subpanel_menuitem_props (copy_to_main_panel): the title, icon, or command is empty."
             exit 10
          fi
       done
@@ -441,7 +441,7 @@ function copy_to_main_panel
 
       # Try find_appropriate_icon with different extensions.
       if (($ENOICON == 1)); then
-         echo "Trying heuristics with icon extension formats while searching for an icon ..."
+         echo "Trying alternate file extensions while searching for an icon ..."
          export ENOICON=0
          case "$icon_ext" in
          'png')
@@ -744,4 +744,3 @@ do
       ;;
    esac
 done
-

--- a/nscde_tools/sysinfo.in
+++ b/nscde_tools/sysinfo.in
@@ -10,6 +10,11 @@ import platform
 import os
 import pwd
 import socket
+import gettext
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 # User Name
 print (pwd.getpwuid(os.getuid()).pw_name)
@@ -24,7 +29,7 @@ try:
     # Internet (IP) Address
     print (socket.gethostbyname(socket.gethostname()))
 except:
-    print ("(none)")
+    print (_("(none)"))
 
 # Internet Domain
 try:
@@ -32,7 +37,7 @@ try:
     domainpart = finddomain.split(".", 1)[1]
     print (domainpart)
 except:
-    print ("(none)")
+    print (_("(none)"))
 
 try:
    import psutil
@@ -55,10 +60,10 @@ try:
    print (str(swapmem_pct) + "% " + "(" + str(swapmem_pct) + "/" + str(swapmem_mb) + ") " + str(swapmem_avail) + "MB")
 
 except ImportError:
-   physmem_mb = "(Not available)"
-   swapmem_mb = "(Not available)"
-   swapmem_avail = "(Not available)"
-   swapmem_pct = "(Not available)"
+   physmem_mb = _("(Not available)")
+   swapmem_mb = _("(Not available)")
+   swapmem_avail = _("(Not available)")
+   swapmem_pct = _("(Not available)")
 
    # Physical Memory (RAM)
    print (physmem_mb)
@@ -70,7 +75,7 @@ except ImportError:
    print (swapmem_pct)
 
    # Virtual Memory in Use
-   print ("(Not available)")
+   print (_("(Not available)"))
 
 # System Last Booted
 # print ("syslastbooted XXX") # XXX

--- a/nscde_tools/themegen.in
+++ b/nscde_tools/themegen.in
@@ -12,14 +12,14 @@ import shutil
 
 nscde_libdir = os.environ.get('NSCDE_LIBDIR')
 if not nscde_libdir:
-   sys.stderr.write("NSCDE_LIBDIR not set. Stop.\n")
+   sys.stderr.write("NSCDE_LIBDIR is not set. Stopping.\n")
    sys.exit(1)
 else:
    sys.path.append(nscde_libdir + "/python")
 
 nscde_datadir = os.environ.get('NSCDE_DATADIR')
 if not nscde_datadir:
-   sys.stderr.write("NSCDE_DATADIR not defined. Stop.\n")
+   sys.stderr.write("NSCDE_DATADIR is not defined. Stopping.\n")
    sys.exit(1)
 
 themegen="""
@@ -42,7 +42,7 @@ from Opts import Opts
 from MotifColors import readMotifColors2
 
 helptxt="""Generate GTK2 and GTK3 theme in style of CDE/Motif
-Directory 'NsCDE' will be be created as ~/.themes/NsCDE
+Directory 'NsCDE' will be created as ~/.themes/NsCDE
 
 Usage:
    themegen <palettename> ncolors gtk2 gtk3
@@ -116,4 +116,3 @@ theme=Theme(opts)
 Globals.colorshash=readMotifColors2(opts.ncolors,opts.currentpalettefile)
 theme.initTheme()
 theme.updateThemeNow()
-

--- a/nscde_tools/themegen.in
+++ b/nscde_tools/themegen.in
@@ -9,23 +9,28 @@
 import os
 import sys
 import shutil
+import gettext
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 nscde_libdir = os.environ.get('NSCDE_LIBDIR')
 if not nscde_libdir:
-   sys.stderr.write("NSCDE_LIBDIR is not set. Stopping.\n")
+   sys.stderr.write(_("NSCDE_LIBDIR is not set. Stopping.\n"))
    sys.exit(1)
 else:
    sys.path.append(nscde_libdir + "/python")
 
 nscde_datadir = os.environ.get('NSCDE_DATADIR')
 if not nscde_datadir:
-   sys.stderr.write("NSCDE_DATADIR is not defined. Stopping.\n")
+   sys.stderr.write(_("NSCDE_DATADIR is not defined. Stopping.\n"))
    sys.exit(1)
 
-themegen="""
+themegen=_("""
 For this script to work you need to install the Python 3
 Qt4 (PyQt4) modules, or Python 3 Qt5 (PyQt5) modules.
-"""
+""")
 
 try:
    from PyQt4 import QtCore, QtGui
@@ -41,7 +46,7 @@ from Theme import Theme
 from Opts import Opts
 from MotifColors import readMotifColors2
 
-helptxt="""Generate GTK2 and GTK3 theme in style of CDE/Motif
+helptxt=_("""Generate GTK2 and GTK3 theme in style of CDE/Motif
 Directory 'NsCDE' will be created as ~/.themes/NsCDE
 
 Usage:
@@ -74,7 +79,7 @@ Examples:
 
     From file which is not in system's nor user's palette directory:
        themegen /home/jdoe/pixmaps/MyNewPalette.dp 8 gtk2 gtk3
-""".format(**locals())
+""").format(**locals())
 
 if len(sys.argv)!=5:
     print (helptxt)
@@ -104,7 +109,7 @@ elif os.path.exists(palettefile):
     opts.currentpalettefile=palettefile
     # nscdetheme="NsCDE-" + os.path.basename(nscdetheme.replace(".dp", ""))
 else:
-    print ('Palette not found: ' + palettefile)
+    print (_('Palette not found: %s') % palettefile)
     sys.exit()
 
 Globals.themedir=nscde_datadir + "/integration/gtk2_gtk3_qt"

--- a/nscde_tools/usleep.in
+++ b/nscde_tools/usleep.in
@@ -8,11 +8,16 @@
 
 import time
 import sys
+import gettext
+import os
+
+_LOCALE_BASE = os.environ.get("NSCDE_DATADIR") or "@NSCDE_DATADIR@"
+_LOCALE_DIR = os.path.normpath(os.path.join(_LOCALE_BASE, os.pardir, "locale"))
+_ = gettext.translation("nscde-tools", localedir=_LOCALE_DIR, fallback=True).gettext
 
 usleep = lambda x: time.sleep(x/1000000.0)
 
 try:
    usleep(int(sys.argv[1]))
 except:
-    print("Usage: usleep <microseconds>")
-
+    print(_("Usage: usleep <microseconds>"))

--- a/nscde_tools/var_append.in
+++ b/nscde_tools/var_append.in
@@ -19,7 +19,7 @@ eval varcontent='$'$varname
 for argv in "$valsep" "$varname" "$varnewval"
 do
    if [ "x$argv" == "x" ]; then
-      echo "Usage: ${0##*/} <separator> <varname> <varvalue>" >&2
+      echo "Usage: ${0##*/} <separator> <variable name> <variable value>" >&2
       if [ "x$varname" != "x" ]; then
          echo "$varcontent"
       fi

--- a/nscde_tools/var_append.in
+++ b/nscde_tools/var_append.in
@@ -6,6 +6,19 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 valsep="$1"
 varname="$2"
 varnewval="$3"
@@ -19,7 +32,7 @@ eval varcontent='$'$varname
 for argv in "$valsep" "$varname" "$varnewval"
 do
    if [ "x$argv" == "x" ]; then
-      echo "Usage: ${0##*/} <separator> <variable name> <variable value>" >&2
+      printf "$(nscde_gettext 'Usage: %s <separator> <variable name> <variable value>')\n" "${0##*/}" >&2
       if [ "x$varname" != "x" ]; then
          echo "$varcontent"
       fi

--- a/nscde_tools/xdowrapper.in
+++ b/nscde_tools/xdowrapper.in
@@ -11,7 +11,7 @@
 
 type -qp xdotool
 if (($? != 0)); then
-   echo "No xdotool found. Exiting." >&2
+   echo "xdotool was not found. Exiting." >&2
    exit 1
 fi
 
@@ -49,4 +49,3 @@ do
 
    (( cnt = cnt + 1 ))
 done
-

--- a/nscde_tools/xdowrapper.in
+++ b/nscde_tools/xdowrapper.in
@@ -6,12 +6,25 @@
 # Licence: GPLv3
 #
 
+TEXTDOMAINDIR="${NSCDE_DATADIR:-@NSCDE_DATADIR@}/../locale"
+TEXTDOMAIN="nscde-tools"
+export TEXTDOMAINDIR TEXTDOMAIN
+
+function nscde_gettext
+{
+   if whence -q gettext; then
+      gettext "$1"
+   else
+      printf '%s' "$1"
+   fi
+}
+
 # This script is workaround for xdotool which is workaround for non-patched FvwmButtons
 # to get names of the subpanels in place.
 
 type -qp xdotool
 if (($? != 0)); then
-   echo "xdotool was not found. Exiting." >&2
+   printf '%s\n' "$(nscde_gettext 'xdotool was not found. Exiting.')" >&2
    exit 1
 fi
 
@@ -24,7 +37,7 @@ function xdofunc
       if (($? == 0)); then
          xdotool search --name "NsCDE-Subpanel${subp}$" > /dev/null 2>&1
          if (($? == 0)); then
-            echo "Refreshing subpanel NsCDE-Subpanel${subp}" >&2
+            printf "$(nscde_gettext 'Refreshing subpanel %s')\n" "NsCDE-Subpanel${subp}" >&2
             $NSCDE_ROOT/bin/nscde_fvwmclnt "Exec exec xdotool search --name "NsCDE-Subpanel${subp}\$" \
                          set_window --name \"\$[infostore.NsCDE-Subpanel${subp}-Name]\" \
                          --icon-name \"\$[infostore.NsCDE-Subpanel${subp}-Name]\""

--- a/po/NsCDE-ColorMgr.hr.po
+++ b/po/NsCDE-ColorMgr.hr.po
@@ -139,3 +139,5 @@ msgstr "Uređivač Boja"
 msgid "Hue"
 msgstr "Nijansa"
 
+msgid "Error occurred while calling Color Selector:"
+msgstr "Dogodila se greška prilikom pozivanja Odabiratelja Boja:"

--- a/po/NsCDE-GWM.hr.po
+++ b/po/NsCDE-GWM.hr.po
@@ -119,50 +119,50 @@ msgstr "Greška Grafičkog Radnopovršinskog Upravljača"
 msgid "Error"
 msgstr "Greška"
 
-msgid "occurred while appending backdrops value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti pozadine u"
+msgid " occurred while appending backdrops value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti pozadine u"
 
-msgid "occurred while changing backdrops value in"
-msgstr "se pojavila prilikom promjene vrijednosti pozadine u"
+msgid " occurred while changing backdrops value in"
+msgstr " se pojavila prilikom promjene vrijednosti pozadine u"
 
-msgid "occurred while appending highlight value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti osvjetljenja u"
+msgid " occurred while appending highlight value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti osvjetljenja u"
 
-msgid "occurred while changing highlight value in"
-msgstr "se pojavila prilikom promjene vrijednosti osvjetljenja u"
+msgid " occurred while changing highlight value in"
+msgstr " se pojavila prilikom promjene vrijednosti osvjetljenja u"
 
-msgid "occurred while appending workspace name label value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti oznake radne površine u"
+msgid " occurred while appending workspace name label value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti oznake radne površine u"
 
-msgid "occurred while changing workspace name label value in"
-msgstr "se pojavila prilikom promjene vrijednosti oznake radne površine u"
+msgid " occurred while changing workspace name label value in"
+msgstr " se pojavila prilikom promjene vrijednosti oznake radne površine u"
 
-msgid "occurred while appending GWM rows value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti GWM redaka u"
+msgid " occurred while appending GWM rows value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti GWM redaka u"
 
-msgid "occurred while changing GWM rows value in"
-msgstr "se pojavila prilikom promjene vrijednosti GWM redaka u"
+msgid " occurred while changing GWM rows value in"
+msgstr " se pojavila prilikom promjene vrijednosti GWM redaka u"
 
-msgid "occurred while adding GWM width scale value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti GWM širine opsega u"
+msgid " occurred while adding GWM width scale value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti GWM širine opsega u"
 
-msgid "occurred while changing GWM width scale value in"
-msgstr "se pojavila prilikom promjene vrijednosti GWM širine opsega u"
+msgid " occurred while changing GWM width scale value in"
+msgstr " se pojavila prilikom promjene vrijednosti GWM širine opsega u"
 
-msgid "occurred while adding balloons display value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti prikaza balona u"
+msgid " occurred while adding balloons display value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti prikaza balona u"
 
-msgid "occurred while changing balloons display value in"
-msgstr "se pojavila prilikom promjene vrijednosti prikaza balona u"
+msgid " occurred while changing balloons display value in"
+msgstr " se pojavila prilikom promjene vrijednosti prikaza balona u"
 
-msgid "occurred while adding skip list value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti prozorske liste izostavljanja u"
+msgid " occurred while adding skip list value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti prozorske liste izostavljanja u"
 
-msgid "occurred while changing skip list value in"
-msgstr "se pojavila prilikom promjene vrijednosti prozorske liste izostavljanja u"
+msgid " occurred while changing skip list value in"
+msgstr " se pojavila prilikom promjene vrijednosti prozorske liste izostavljanja u"
 
-msgid "occurred while appending window content type value in"
-msgstr "se pojavila prilikom dodavanja vrijednosti tipa sadržaja prozora u"
+msgid " occurred while appending window content type value in"
+msgstr " se pojavila prilikom dodavanja vrijednosti tipa sadržaja prozora u"
 
-msgid "occurred while changing window content type value in"
-msgstr "se pojavila prilikom promjene vrijednosti tipa sadržaja prozora u"
+msgid " occurred while changing window content type value in"
+msgstr " se pojavila prilikom promjene vrijednosti tipa sadržaja prozora u"

--- a/po/NsCDE-GWM.hr.po
+++ b/po/NsCDE-GWM.hr.po
@@ -119,51 +119,50 @@ msgstr "Greška Grafičkog Radnopovršinskog Upravljača"
 msgid "Error"
 msgstr "Greška"
 
-msgid "emerged while appending backdrops value in"
+msgid "occurred while appending backdrops value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti pozadine u"
 
-msgid "emerged while changing backdrops value in"
+msgid "occurred while changing backdrops value in"
 msgstr "se pojavila prilikom promjene vrijednosti pozadine u"
 
-msgid "emerged while appending highlight value in"
+msgid "occurred while appending highlight value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti osvjetljenja u"
 
-msgid "emerged while changing highlight value in"
+msgid "occurred while changing highlight value in"
 msgstr "se pojavila prilikom promjene vrijednosti osvjetljenja u"
 
-msgid "emerged while appending workspace name label value in"
+msgid "occurred while appending workspace name label value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti oznake radne površine u"
 
-msgid "emerged while changing workspace name label value in"
+msgid "occurred while changing workspace name label value in"
 msgstr "se pojavila prilikom promjene vrijednosti oznake radne površine u"
 
-msgid "emerged while appending GWM rows value in"
+msgid "occurred while appending GWM rows value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti GWM redaka u"
 
-msgid "emerged while changing GWM rows value in"
+msgid "occurred while changing GWM rows value in"
 msgstr "se pojavila prilikom promjene vrijednosti GWM redaka u"
 
-msgid "emerged while adding GWM width scale value in"
+msgid "occurred while adding GWM width scale value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti GWM širine opsega u"
 
-msgid "emerged while changing GWM width scale value in"
+msgid "occurred while changing GWM width scale value in"
 msgstr "se pojavila prilikom promjene vrijednosti GWM širine opsega u"
 
-msgid "emerged while adding balloons display value in"
+msgid "occurred while adding balloons display value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti prikaza balona u"
 
-msgid "emerged while changing balloons display value in"
+msgid "occurred while changing balloons display value in"
 msgstr "se pojavila prilikom promjene vrijednosti prikaza balona u"
 
-msgid "emerged while adding skip list value in"
+msgid "occurred while adding skip list value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti prozorske liste izostavljanja u"
 
-msgid "emerged while changing skip list value in"
+msgid "occurred while changing skip list value in"
 msgstr "se pojavila prilikom promjene vrijednosti prozorske liste izostavljanja u"
 
-msgid "emerged while appending window content type value in"
+msgid "occurred while appending window content type value in"
 msgstr "se pojavila prilikom dodavanja vrijednosti tipa sadržaja prozora u"
 
-msgid "emerged while changing window content type value in"
+msgid "occurred while changing window content type value in"
 msgstr "se pojavila prilikom promjene vrijednosti tipa sadržaja prozora u"
-

--- a/po/NsCDE-Subpanel.hr.po
+++ b/po/NsCDE-Subpanel.hr.po
@@ -49,7 +49,7 @@ msgstr "Komanda:"
 msgid "Icon File:"
 msgstr "Datoteka s Ikonom"
 
-msgid " Do not check for command existance"
+msgid " Do not check whether the command exists"
 msgstr " Ne provjeravaj da li komanda postoji"
 
 msgid "Apply"
@@ -93,4 +93,3 @@ msgstr "U Redu"
 
 msgid "Close"
 msgstr "Zatvori"
-

--- a/po/NsCDE.hr.po
+++ b/po/NsCDE.hr.po
@@ -585,11 +585,8 @@ msgstr "Čuvar Ekrana je onemogućen u konfiguraciji. Pogledajte \"nscde_use_xsc
 msgid "Cannot find"
 msgstr "Ne mogu pronaći"
 
-msgid "in PATH"
-msgstr "u stazi"
-
-msgid "Cannot find \"xscreensaver-command\" in PATH"
-msgstr "Ne mogu pronaći \"xscreensaver-command\" u stazi"
+msgid " in PATH:"
+msgstr " u stazi:"
 
 msgid "No X Screen Saver (xscreensaver) is running on display"
 msgstr "X Čuvar Ekrana (xscreensaver) nije pokrenut na zaslonu"
@@ -627,17 +624,17 @@ msgstr "Funkcija Provjere Pošte"
 msgid "Default E-mail application is not set. You can set"
 msgstr "Zadana aplikacija E-Pošte nije postavljena. Možete postaviti"
 
-msgid "in your"
-msgstr "u vašoj"
+msgid " in your"
+msgstr " u vašoj"
 
-msgid "file and it will be called when e-mail icon is clicked. For visual letter icon notifications to work, a FVWM function called"
-msgstr "datoteci i biti će pozvana kada se klikne ikona e-pošte. Za vizualne obavijesti ikone pisma, FVWM funkcija zvana"
+msgid " file and it will be called when e-mail icon is clicked. For visual letter icon notifications to work, a FVWM function called"
+msgstr " datoteci i biti će pozvana kada se klikne ikona e-pošte. Za vizualne obavijesti ikone pisma, FVWM funkcija zvana"
 
-msgid "must be enabled and edited in your"
-msgstr "mora biti omogućena i uređena u vašoj"
+msgid " must be enabled and edited in your"
+msgstr " mora biti omogućena i uređena u vašoj"
 
-msgid "file. See the documentation for ideas how to set up personal e-mail notifications."
-msgstr "datoteci. Konzultirajte dokumentaciju za ideje kako postaviti osobne e-mail obavijesti."
+msgid " file. See the documentation for ideas how to set up personal e-mail notifications."
+msgstr " datoteci. Konzultirajte dokumentaciju za ideje kako postaviti osobne e-mail obavijesti."
 
 msgid "Calendar Function"
 msgstr "Funkcija Kalendara"
@@ -648,8 +645,8 @@ msgstr "Zadana akcija nije postavljena. Ako želite pozvati neku aplikaciju kada
 msgid "FVWM function in your"
 msgstr "FVWM funkciju u vašoj"
 
-msgid "file. See the documentation for ideas how to set that up."
-msgstr "datoteci. Konzultirajte dokumentaciju za ideje kako to postaviti."
+msgid " file. See the documentation for ideas how to set that up."
+msgstr " datoteci. Konzultirajte dokumentaciju za ideje kako to postaviti."
 
 msgid "Audio Mixer Function"
 msgstr "Funkcija Audio Miksera"
@@ -837,8 +834,8 @@ msgstr "Greška prilikom stvaranja"
 msgid "Error"
 msgstr "Greška"
 
-msgid "occurred while checking config file"
-msgstr "se dogodila prilikom provjeravanja konfiguracijske datoteke"
+msgid " occurred while checking config file"
+msgstr " se dogodila prilikom provjeravanja konfiguracijske datoteke"
 
 msgid "Screenshot Function Error"
 msgstr "Greška Funkcije Slikanja Ekrana"

--- a/po/NsCDE.hr.po
+++ b/po/NsCDE.hr.po
@@ -837,7 +837,7 @@ msgstr "Greška prilikom stvaranja"
 msgid "Error"
 msgstr "Greška"
 
-msgid "occured while checking config file"
+msgid "occurred while checking config file"
 msgstr "se dogodila prilikom provjeravanja konfiguracijske datoteke"
 
 msgid "Screenshot Function Error"
@@ -905,7 +905,7 @@ msgstr "Ime Postave fonta mora biti definirano prije pohrane!"
 msgid "Not all applications have the ability to dynamically change their font. Such applications may have to be restarted for effect to take place."
 msgstr "Nemaju sve aplikacije mogućnost dinamički promijeniti svoj font. Takve aplikacije će možda morati biti restartane da bi došlo do efekta."
 
-msgid "Error occured while calling Color Selector:"
+msgid "Error occurred while calling Color Selector:"
 msgstr "Dogodila se greška prilikom pozivanja Odabiratelja Boja:"
 
 msgid "ERROR: Old value of FP.LeftLaunchersNum is not a number:"
@@ -1390,4 +1390,3 @@ msgstr "Pomoć za Dijalog Sistemske Akcije"
 
 msgid "System Information Help"
 msgstr "Pomoć za Sistemske Informacije"
-

--- a/po/nscde-bootstrap.hr.po
+++ b/po/nscde-bootstrap.hr.po
@@ -253,7 +253,7 @@ msgstr "Možete postaviti $[infostore.terminal] varijablu na vaš omiljeni"
 msgid "terminal program in"
 msgstr "terminalski program u"
 
-msgid "or leave autodiscovery"
+msgid "or leave autodiscovery."
 msgstr "ili ostavite automatsko otkrivanje"
 
 msgid "Hint: See"
@@ -285,4 +285,3 @@ msgstr "Instalira se zadana rofi config datoteka kao "
 
 msgid "Backing up pre-NsCDE GTK and Qt config files as "
 msgstr "Kreiram pre-NsCDE kopiju GTK i Qt konfiguracija kao "
-

--- a/po/nscde-bootstrap.hr.po
+++ b/po/nscde-bootstrap.hr.po
@@ -253,8 +253,8 @@ msgstr "Možete postaviti $[infostore.terminal] varijablu na vaš omiljeni"
 msgid "terminal program in"
 msgstr "terminalski program u"
 
-msgid "or leave autodiscovery."
-msgstr "ili ostavite automatsko otkrivanje"
+msgid " or leave autodiscovery."
+msgstr " ili ostavite automatsko otkrivanje."
 
 msgid "Hint: See"
 msgstr "Savjet: Pogledajte"


### PR DESCRIPTION
## Summary

This is part 2 of the Simplified Chinese localization series and depends on #235.

It makes the remaining user-visible runtime messages translatable without embedding Chinese text in the source:

- Route 103 `Title` and `ChangeTitle` sites across 22 FvwmScript files through gettext-aware `LocaleTitle` handling.
- Localize previously hardcoded diagnostics in helper scripts and Python modules.
- Add gettext initialization and domain routing to helper tools.
- Replace fragile sentence fragments with complete translatable messages.
- Perform runtime interpolation only after gettext lookup.

The final point avoids patterns such as `gettext -s "Not available on $OS"`, where the shell expands `$OS` before gettext receives the key and therefore prevents a literal PO entry from matching.

## Why this is separate

Translation catalogs cannot cover strings that remain hardcoded or are assembled in an order incompatible with Chinese grammar.

This PR provides reusable, language-neutral localization infrastructure. The Chinese catalogs remain isolated in #237.

## Series

1. English corrections — #235
2. **Localization infrastructure** — this PR
3. Complete Simplified Chinese localization — #237

These PRs must be merged in order.

Because all three target upstream `master`, this PR temporarily includes #235. Its diff will shrink automatically after #235 is merged.

## Scope

The infrastructure layer itself contains:

- 4 focused, signed commits
- 64 affected files relative to the #235 head
- No Simplified Chinese catalog content
- Literal gettext keys with runtime values inserted only after lookup
